### PR TITLE
Extend templating system with utils

### DIFF
--- a/src/codegen.py
+++ b/src/codegen.py
@@ -17,7 +17,7 @@ try:
     from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
     from yaml import Loader, Dumper
-from jinja2 import Template
+from jinja2 import Environment, FileSystemLoader
 
 _VERSION = '0.1.0'
 _DEBUG = False
@@ -54,16 +54,14 @@ def generateSourceFile(template, peripheral, templateExtension, outputDir):
     with open(peripheralOutputPath, 'x') as peripheralOutputFile:
       peripheralOutputFile.write(peripheralGen)
 
-def generateSourceFilesForTemplate(templateFile, inputFiles, outputDir):
+def generateSourceFilesForTemplate(env, templateFile, inputFiles, outputDir):
   """
   Generates a series of source files for a provided template file.
   """
   # Open template
   with open(templateFile, 'r') as templateContents:
-    templateObject = Template(
-      templateContents.read(),
-      trim_blocks=True,
-      lstrip_blocks=True
+    templateObject = env.from_string(
+      templateContents.read()
     )
     _, templateExtension = os.path.splitext(templateFile)
     
@@ -104,11 +102,18 @@ def gen(argv):
       inputFiles.append(arg)
     elif opt == '-d':
       _DEBUG = True
-    
+
   if _DEBUG:
     print("Generating " + str(len(inputFiles)) + " file(s)")
+
+  # Setup Jinja environment
+  env = Environment(
+    loader=FileSystemLoader('./templates'),
+    trim_blocks=True,
+    lstrip_blocks=True
+  )
   for templateFile in templateFiles:
-    generateSourceFilesForTemplate(templateFile, inputFiles, outputDir)
+    generateSourceFilesForTemplate(env, templateFile, inputFiles, outputDir)
 
 if __name__ == "__main__":
     gen(sys.argv[1:])

--- a/templates/macros.jinja2
+++ b/templates/macros.jinja2
@@ -1,0 +1,74 @@
+{# 
+    Macro objectKey
+
+    For a YAML object, this will get the key.
+    ex.
+
+    - key:
+      foo: bar
+      fez: baz
+
+    Loaded in a Python dict, this is interpreted as:
+
+    {
+        "key": None,
+        "foo": "bar",
+        "fez": "baz"
+    }
+
+    This macro gets "key" by checking for any
+    property that has a value of `None`.
+#}
+
+{% macro object_key(yamlObject) %}
+{% for prop, val in yamlObject.items() %}
+{% if val == None -%}
+{{prop}}
+{%- endif %}
+{% endfor %}
+{% endmacro %}
+
+{#
+    Macro padString
+
+    This can be useful to pad a string with comments or
+    a given number of spaces.
+
+    x = """lorem
+    ipsum"""
+
+    {{ pad_string("# ", x) }}
+#}
+
+{% macro pad_string(padding, contentString) %}
+{% for line in contentString.splitlines() %}
+{{padding}}{{line}}
+{% endfor %}
+{% endmacro %}
+
+{#
+    Macro license
+
+    This produces a license header based on the
+    license parameter. It generates the header
+    for a provided company and copyright year.
+#}
+
+{% macro license(company, year, license) %}
+{% if license == "Apache-2.0" %}
+Copyright (C) {{year}} {{company}}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endif %}
+{% endmacro %}
+

--- a/templates/raspberrypi.py
+++ b/templates/raspberrypi.py
@@ -1,27 +1,8 @@
-# Copyright (C) 2019 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+{% import 'macros.jinja2' as utils %}
+{{ utils.pad_string('# ', utils.license('Google Inc.', '2019', info.license.name)) -}}
 #
 # Auto-generated file for {{ info.title }} v{{ info.version }}.
 # Generated from {{ fileName }} using Cyanobyte Codegen v{{ version }}
-
-{% macro objectKey(yamlObject) %}
-{% for prop, val in yamlObject.items() %}
-{% if val == None -%}
-{{prop}}
-{%- endif %}
-{% endfor %}
-{% endmacro %}
 
 import sys
 try:
@@ -32,11 +13,11 @@ except ImportError:
 
 class {{ info.title }}
     """
-    {{ info.description }}
+{{utils.pad_string("    ", info.description)}}
     """
     DEVICE_ADDRESS = {{i2c.address}}
     {% for register in registers %}
-    REGISTER_{{objectKey(register).upper()}} = {{register.address}}
+    REGISTER_{{utils.object_key(register).upper()}} = {{register.address}}
     {% endfor %}
 
     def __init__(self):
@@ -51,29 +32,29 @@ class {{ info.title }}
 
     {% for register in registers %}
 
-    def get{{objectKey(register)}}():
+    def get_{{utils.object_key(register).lower()}}():
         """
-        {{register.description}}
+{{utils.pad_string("        ", register.description)}}
         """
         val = bus.read_i2c_block_data(
             DEVICE_ADDRESS,
-            REGISTER_{{objectKey(register).upper()}}
+            REGISTER_{{utils.object_key(register).upper()}}
         )
         {% if i2c.endian == 'little' %}
         val = self._swap_endian(val)
         {% endif %}
         return val
 
-    def set{{objectKey(register)}}(data):
+    def set_{{utils.object_key(register).lower()}}(data):
         """
-        {{register.description}}
+{{utils.pad_string("        ", register.description)}}
         """
         {% if i2c.endian == 'little' %}
         data = self._swap_endian(data)
         {% endif %}
         bus.write_i2c_block_data(
             DEVICE_ADDRESS,
-            REGISTER_{{objectKey(register).upper()}},
+            REGISTER_{{utils.object_key(register).upper()}},
             data
         )
     {% endfor %}

--- a/test/sampleData/Mcp4725.py
+++ b/test/sampleData/Mcp4725.py
@@ -1,11 +1,11 @@
 # Copyright (C) 2019 Google Inc.
-#
+# 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,6 @@
 #
 # Auto-generated file for Mcp4725 v0.1.0.
 # Generated from peripherals/Mcp4725.yaml using Cyanobyte Codegen v0.1.0
-
 
 import sys
 try:
@@ -26,6 +25,7 @@ except ImportError:
 class Mcp4725
     """
     Microchip 4725 Digital-to-Analog Converter
+
     """
     DEVICE_ADDRESS = 98
     REGISTER_VOUT = 64
@@ -40,12 +40,12 @@ class Mcp4725
         return val >> 8 | val << 8
 
 
-    def getVOut():
+    def get_vout():
         """
         VOut = (Vcc * value) / 4096
-The output is a range between 0 and Vcc with
-steps of Vcc/4096.
-In a 3.3v system, each step is 800 microvolts.
+        The output is a range between 0 and Vcc with
+        steps of Vcc/4096.
+        In a 3.3v system, each step is 800 microvolts.
 
         """
         val = bus.read_i2c_block_data(
@@ -55,12 +55,12 @@ In a 3.3v system, each step is 800 microvolts.
         val = self._swap_endian(val)
         return val
 
-    def setVOut(data):
+    def set_vout(data):
         """
         VOut = (Vcc * value) / 4096
-The output is a range between 0 and Vcc with
-steps of Vcc/4096.
-In a 3.3v system, each step is 800 microvolts.
+        The output is a range between 0 and Vcc with
+        steps of Vcc/4096.
+        In a 3.3v system, each step is 800 microvolts.
 
         """
         data = self._swap_endian(data)
@@ -70,10 +70,10 @@ In a 3.3v system, each step is 800 microvolts.
             data
         )
 
-    def getEEPROM():
+    def get_eeprom():
         """
         If EEPROM is set, the saved voltage output will
-be loaded from power-on.
+        be loaded from power-on.
 
         """
         val = bus.read_i2c_block_data(
@@ -83,10 +83,10 @@ be loaded from power-on.
         val = self._swap_endian(val)
         return val
 
-    def setEEPROM(data):
+    def set_eeprom(data):
         """
         If EEPROM is set, the saved voltage output will
-be loaded from power-on.
+        be loaded from power-on.
 
         """
         data = self._swap_endian(data)


### PR DESCRIPTION
This adds a few template macros that can do common operations.
Docstrings are properly indented.
License header is programmatically generated.
Makes Python API snake_case.

Issue: #6
Issue:  #17