### PR TITLE
Add initial version of the JSON Schema validator

### DIFF
--- a/spec/cyanobyte.schema.json
+++ b/spec/cyanobyte.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://github.com/cyanobyte/cyanobyte.schema.json",
+  "title": "CyanoByte Specification Validator",
+  "description": "This file is used to validate whether a given document meets the CyanoByte specification.",
+  "type": "object",
+  "properties": {
+    "cyanobyte": {
+      "description": "The version of the CyanoByte specification this file follows.",
+      "type": "string",
+      "pattern": "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$"
+    },
+    "info": {
+      "description": "Info block of the file",
+      "type": "object",
+      "properties": {
+        "title": {
+          "description": "The title of the document. This should be used as the class name in the auto-generated code and therefore should be short (e.g. the part name)."
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the document."
+          "type": "string"
+        },
+        "contact": {
+          "description": "Contact info for the maintainer."
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "Name of the maintainer."
+              "type": "string"
+            },
+            "url": {
+              "description": "URL of the maintainer organization."
+              "type": "string",
+              "format": "uri"
+            },
+            "email": {
+              "description": "Email address for the maintainer.",
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "required": [ "name", "url", "email" ]
+        },
+        "license": {
+          "description": "License this document uses. TODO: Add validation other than it being a string.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version number for this document using kind of SymVer.",
+          "type": "string",
+          "pattern": "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$"
+        }
+      },
+      "required": [ "title", "description", "contact", "license", "version" ]
+    },
+    "required": [ "cyanobyte", "info" ]
+}

--- a/spec/cyanobyte.schema.json
+++ b/spec/cyanobyte.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://github.com/cyanobyte/spec/cyanobyte.schema.json",
+  "$id": "https://github.com/google/cyanobyte/spec/cyanobyte.schema.json",
   "title": "CyanoByte Specification Validator",
   "description": "This file is used to validate whether a given document meets the CyanoByte specification.",
   "type": "object",
@@ -48,7 +48,17 @@
         },
         "license": {
           "description": "License this document uses. TODO: Add validation other than it being a string.",
-          "type": "string"
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "A SPDX compliant license identifier",
+              "type": "string"
+            },
+            "url": {
+              "description": "If the license name is not SPDX compliant, this can link to the license",
+              "type": "string"
+            }
+          }
         },
         "version": {
           "description": "Version number for this document using kind of semver.",

--- a/spec/cyanobyte.schema.json
+++ b/spec/cyanobyte.schema.json
@@ -7,31 +7,30 @@
   "properties": {
     "cyanobyte": {
       "description": "The version of the CyanoByte specification this file follows.",
-      "type": "string",
-      "pattern": "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$"
+      "type": "string"
     },
     "info": {
       "description": "Info block of the file",
       "type": "object",
       "properties": {
         "title": {
-          "description": "The title of the document. This should be used as the class name in the auto-generated code and therefore should be short (e.g. the part name)."
+          "description": "The title of the document. This should be used as the class name in the auto-generated code and therefore should be short (e.g. the part name).",
           "type": "string"
         },
         "description": {
-          "description": "A description of the document."
+          "description": "A description of the document.",
           "type": "string"
         },
         "contact": {
-          "description": "Contact info for the maintainer."
+          "description": "Contact info for the maintainer.",
           "type": "object",
           "properties": {
             "name": {
-              "description": "Name of the maintainer."
+              "description": "Name of the maintainer.",
               "type": "string"
             },
             "url": {
-              "description": "URL of the maintainer organization."
+              "description": "URL of the maintainer organization.",
               "type": "string",
               "format": "uri"
             },
@@ -41,7 +40,11 @@
               "format": "email"
             }
           },
-          "required": [ "name", "url", "email" ]
+          "required": [
+            "name",
+            "url",
+            "email"
+          ]
         },
         "license": {
           "description": "License this document uses. TODO: Add validation other than it being a string.",
@@ -49,11 +52,165 @@
         },
         "version": {
           "description": "Version number for this document using kind of SymVer.",
-          "type": "string",
-          "pattern": "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$"
+          "type": "string"
         }
       },
-      "required": [ "title", "description", "contact", "license", "version" ]
+      "required": [
+        "title",
+        "description",
+        "contact",
+        "license",
+        "version"
+      ]
     },
-    "required": [ "cyanobyte", "info" ]
+    "i2c": {
+      "description": "I2C settings",
+      "type": "object",
+      "properties": {
+        "addressType": {
+          "description": "Addressing type of the component.",
+          "type": "string",
+          "enum": [
+            "7-bit",
+            "10-bit"
+          ]
+        },
+        "address": {
+          "description": "I2C Address of the component",
+          "type": "integer"
+        },
+        "addressMask": {
+          "description": "Address mask for addresses that can be altered"
+        }
+      },
+      "required": [
+        "addressType",
+        "address",
+        "addressMask"
+      ]
+    },
+    "registers": {
+      "description": "Chip registers",
+      "type": "array",
+      "items": {
+        "description": "Outer object",
+        "type": "object",
+        "patternProperties": {
+          "^.*$": {
+            "description": "Chip register",
+            "type": "object",
+            "properties": {
+              "title": {
+                "description": "Title of the register",
+                "type": "string"
+              },
+              "description": {
+                "description": "Description of the register",
+                "type": "string"
+              },
+              "address": {
+                "description": "Address of the register",
+                "type": "integer"
+              },
+              "length": {
+                "description": "Length of the register in bits.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "address",
+              "length"
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "functions": {
+      "description": "Chip functions",
+      "type": "array",
+      "items": {
+        "description": "Outer object",
+        "type": "object",
+        "patternProperties": {
+          "^.*$": {
+            "description": "Chip function",
+            "type": "object",
+            "properties": {
+              "title": {
+                "description": "Title of the function",
+                "type": "string"
+              },
+              "description": {
+                "description": "Description of the function",
+                "type": "string"
+              },
+              "register": {
+                "description": "Register of the function",
+                "type": "string"
+              },
+              "readWrite": {
+                "description": "Can you read or write to this register",
+                "type": "string",
+                "enum": [
+                  "R",
+                  "R/W",
+                  "W",
+                  "n"
+                ]
+              },
+              "bitStart": {
+                "description": "What is the starting bit?",
+                "type": "integer"
+              },
+              "bitEnd": {
+                "description": "What is the ending bit?",
+                "type": "integer"
+              },
+              "type": {
+                "description": "What type of value is this?",
+                "type": "string",
+                "enum": [
+                  "enum"
+                ]
+              },
+              "enum": {
+                "description": "List of values",
+                "type": "array",
+                "items": {
+                  "description": "Enum value",
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "description": "Enum title",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Enum value",
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "register",
+              "readWrite",
+              "bitStart",
+              "bitEnd",
+              "type"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "cyanobyte",
+    "info"
+  ]
 }

--- a/spec/cyanobyte.schema.json
+++ b/spec/cyanobyte.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://github.com/cyanobyte/cyanobyte.schema.json",
+  "$id": "http://github.com/cyanobyte/spec/cyanobyte.schema.json",
   "title": "CyanoByte Specification Validator",
   "description": "This file is used to validate whether a given document meets the CyanoByte specification.",
   "type": "object",
@@ -51,7 +51,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Version number for this document using kind of SymVer.",
+          "description": "Version number for this document using kind of semver.",
           "type": "string"
         }
       },
@@ -80,7 +80,8 @@
           "type": "integer"
         },
         "addressMask": {
-          "description": "Address mask for addresses that can be altered"
+          "description": "Address mask for addresses that can be altered",
+          "type": "integer"
         }
       },
       "required": [
@@ -113,7 +114,7 @@
                 "type": "integer"
               },
               "length": {
-                "description": "Length of the register in bits.",
+                "description": "Length of the register in bits",
                 "type": "integer"
               }
             },
@@ -152,7 +153,7 @@
                 "type": "string"
               },
               "readWrite": {
-                "description": "Can you read or write to this register",
+                "description": "Can you read and/or write to this register",
                 "type": "string",
                 "enum": [
                   "R",


### PR DESCRIPTION
This adds an initial version of the JSON Schema that will be used to validate CyanoByte documents in reference to #7. The JSON equivalent of the MCP9808 file as created by [an online YAML to JSON validator](https://codebeautify.org/yaml-to-json-xml-csv) is attached to test.

[cyanobyte_validator_test.json.txt](https://github.com/google/cyanobyte/files/2990529/cyanobyte_validator_test.json.txt)