### PR TITLE
Fix Python linting error E301

### DIFF
--- a/templates/raspberrypi.py
+++ b/templates/raspberrypi.py
@@ -36,9 +36,9 @@ class {{ info.title }}:
     def __init__(self):
         # Initialize connection to peripheral
         self.bus = smbus.SMBus(1)
-
     {% for register in registers %}
     {% for key in register.keys() %}
+
     def get_{{key.lower()}}(self):
         """
 {{utils.pad_string("        ", register[key].description)}}


### PR DESCRIPTION
This slightly naive fix moves the whitespace to the start of the register loop, ensuring each method within the Python class is separated by a single line- https://lintlyci.github.io/Flake8Rules/rules/E301.html