### PR TITLE
Break out the functions attribute

### DIFF
--- a/peripherals/ADS1015.yaml
+++ b/peripherals/ADS1015.yaml
@@ -43,7 +43,7 @@ registers:
       length: 16
       title: ADC Value
       description: Conversion register contains the result of the last conversion
-functions:
+fields:
   - SampleRate:
       title: Setup sample rate for reading analog voltage
       description: |
@@ -141,10 +141,10 @@ functions:
         - CHANNEL_4:
             title: Channel 4
             value: 0b11
+functions:
   - analog:
       title: Value read from ADC
       description: Reads the analog voltage in Volts
-      readWrite: 'n'
       computed:
         - read:
             input:

--- a/peripherals/BMP280.yaml
+++ b/peripherals/BMP280.yaml
@@ -140,7 +140,6 @@ functions:
   - temperature:
       title: Temperature as read by sensor
       description: Reads the temperature
-      readWrite: 'n'
       computed:
         - asRaw:
             variables:
@@ -228,7 +227,6 @@ functions:
   - pressure:
       title: Pressure as read by sensor
       description: Reads the atmospheric pressure
-      readWrite: 'n'
       computed:
         - asRaw:
             variables:

--- a/peripherals/MCP4725.yaml
+++ b/peripherals/MCP4725.yaml
@@ -51,7 +51,7 @@ registers:
         If EEPROM is set, the saved voltage output will
         be loaded from power-on.
 
-functions:
+fields:
   - digitalOut:
       title: Digital (binary) output
       description: |
@@ -68,12 +68,12 @@ functions:
         - GND:
             title: Ground
             value: 0b000000000000
+functions:
   - setVOut:
       title: Set output voltage
       description: set vout
       type: number
       register: '#/registers/EEPROM'
-      readWrite: 'n'
       bitStart: 12
       bitEnd: 0
       computed:
@@ -89,7 +89,6 @@ functions:
       description: get vout
       type: number
       register: '#/registers/EEPROM'
-      readWrite: 'n'
       bitStart: 12
       bitEnd: 0
       computed:

--- a/peripherals/MCP9808.yaml
+++ b/peripherals/MCP9808.yaml
@@ -37,7 +37,7 @@ registers:
             and Alert output polarity and mode (Comparator Output or Interrupt
             Output mode) are user-configurable.
 
-functions:
+fields:
     - limitHysteresis:
         title: TUPPER and TLOWER Limit Hysteresis bits
         description: |

--- a/peripherals/TCS3472.yaml
+++ b/peripherals/TCS3472.yaml
@@ -55,7 +55,7 @@ registers:
       title: Blue channel
       description: Blue light as an int. Divide by ambient light to get scaled number.
 
-functions:
+fields:
   - init:
       title: Setup the device configuration
       description: Enable RGBC and Power

--- a/spec/cyanobyte.schema.json
+++ b/spec/cyanobyte.schema.json
@@ -173,8 +173,8 @@
         "additionalProperties": false
       }
     },
-    "functions": {
-      "description": "Chip functions",
+    "fields": {
+      "description": "Subcomponents of a register",
       "type": "array",
       "items": {
         "description": "Outer object",
@@ -245,6 +245,84 @@
               "title",
               "description",
               "readWrite"
+            ]
+          }
+        }
+      }
+    },
+    "functions": {
+      "description": "Chip functions",
+      "type": "array",
+      "items": {
+        "description": "Outer object",
+        "type": "object",
+        "patternProperties": {
+          "^.*$": {
+            "description": "Chip function",
+            "type": "object",
+            "properties": {
+              "title": {
+                "description": "Title of the function",
+                "type": "string"
+              },
+              "description": {
+                "description": "Description of the function",
+                "type": "string"
+              },
+              "register": {
+                "description": "Register of the function",
+                "type": "string"
+              },
+              "computed": {
+                "description": "Properties for a computed element",
+                "type": "array",
+                "items": {
+                  "description": "A computation",
+                  "type": "object",
+                  "patternProperties": {
+                    "^.*$": {
+                      "description": "Title of the computation",
+                      "type": "object",
+                      "properties": {
+                        "variables": {
+                          "description": "All variables used in the computation",
+                          "type": "array",
+                          "items": {
+                            "description": "Variable name",
+                            "type": "object",
+                            "patternProperties": {
+                              "^.$": {
+                                "description": "Variable name",
+                                "type": "string",
+                                "enum": [
+                                  "int8",
+                                  "int16",
+                                  "int32",
+                                  "uint8",
+                                  "uint16",
+                                  "uint32"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "logic": {
+                          "description": "Set of logical operations",
+                          "type": "array"
+                        },
+                        "return": {
+                          "description": "The variable or variable array to return",
+                          "type": ["string", "array"]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description"
             ]
           }
         }

--- a/templates/arduino.cpp
+++ b/templates/arduino.cpp
@@ -133,40 +133,44 @@ int {{info.title}}::write{{key}}({{cpp.numtype(length)}} data) {
 {% endfor %}
 {%- endfor %}
 
-{% for function in functions %}
-{% for key in function.keys() %}
-{% if 'R' is in(function[key].readWrite) %}
+{% for field in fields %}
+{% for key in field.keys() %}
+{% if 'R' is in(field[key].readWrite) %}
 {# Getter #}
-{{cpp.registerSize(registers, function[key].register[12:])}} {{info.title}}::get{{key}}() {
+{{cpp.registerSize(registers, field[key].register[12:])}} {{info.title}}::get{{key}}() {
     // Read register data
-    // '#/registers/{{function[key].register[12:]}}' > '{{function[key].register[12:]}}'
-    uint8_t val = read{{function[key].register[12:]}}();
+    // '#/registers/{{field[key].register[12:]}}' > '{{field[key].register[12:]}}'
+    uint8_t val = read{{field[key].register[12:]}}();
     // Mask register value
-    val = val & {{utils.mask(function[key].bitStart, function[key].bitEnd)}};
-    {% if function[key].bitEnd %}
+    val = val & {{utils.mask(field[key].bitStart, field[key].bitEnd)}};
+    {% if field[key].bitEnd %}
     // Bitshift value
-    val = val >> {{function[key].bitEnd}};
+    val = val >> {{field[key].bitEnd}};
     {% endif %}
     return val;
 }
 {% endif -%}
 
-{%- if 'W' is in(function[key].readWrite) %}
+{%- if 'W' is in(field[key].readWrite) %}
 {# Setter #}
 
 int {{info.title}}::set{{key}}(uint8_t data) {
-    {% if function[key].bitEnd %}
+    {% if field[key].bitEnd %}
     // Bitshift value
-    data = data << {{function[key].bitEnd}};
+    data = data << {{field[key].bitEnd}};
     {% endif %}
     // Read current register data
-    // '#/registers/{{function[key].register[12:]}}' > '{{function[key].register[12:]}}'
-    uint8_t register_data = read{{function[key].register[12:]}}();
+    // '#/registers/{{field[key].register[12:]}}' > '{{field[key].register[12:]}}'
+    uint8_t register_data = read{{field[key].register[12:]}}();
     register_data = register_data | data;
-    return write{{function[key].register[12:]}}(register_data);
+    return write{{field[key].register[12:]}}(register_data);
 }
 {% endif %}
+{% endfor %}
+{% endfor %}
 
+{% for function in functions %}
+{% for key in function.keys() %}
 {% if function[key].computed %}
 {% for compute in function[key].computed %}
 {% for computeKey in compute.keys() %}

--- a/templates/arduino.h
+++ b/templates/arduino.h
@@ -44,19 +44,19 @@
 {% endfor %}
 {% endfor %}
 
-{# Create enums for functions #}
-{% for function in functions %}
-{% for key in function.keys() %}
-{% if function[key].enum %}
+{# Create enums for fields #}
+{% for field in fields %}
+{% for key in field.keys() %}
+{% if field[key].enum %}
 {# Create enum #}
 /*
-{{utils.pad_string(" * ", "Valid values for " + function[key].title)}}
+{{utils.pad_string(" * ", "Valid values for " + field[key].title)}}
  */
 enum {{key}} {
     {% set args = namespace(index=0) %}
-    {% for enumObject in function[key].enum %}
+    {% for enumObject in field[key].enum %}
     {% for enumKey in enumObject.keys() %}
-    {{key.upper()}}_{{enumKey.upper()}} = {{enumObject[enumKey].value}}{{- "," if args.index + 1 < function[key].enum | length }} // {{enumObject[enumKey].title}}
+    {{key.upper()}}_{{enumKey.upper()}} = {{enumObject[enumKey].value}}{{- "," if args.index + 1 < field[key].enum | length }} // {{enumObject[enumKey].title}}
     {% set args.index = args.index + 1 %}
     {% endfor %}
     {% endfor %}
@@ -86,21 +86,25 @@ class {{info.title}} {
         int write{{key}}({{cpp.numtype(length)}} data);
         {% endfor %}
         {%- endfor %}
-        {% for function in functions %}
-        {% for key in function.keys() %}
-        {% if 'R' is in(function[key].readWrite) %}
+        {% for field in fields %}
+        {% for key in field.keys() %}
+        {% if 'R' is in(field[key].readWrite) %}
         /**
-{{utils.pad_string("         * ", function[key].description)}}
+{{utils.pad_string("         * ", field[key].description)}}
          */
-        {{cpp.registerSize(registers, function[key].register[12:])}} get{{key}}();
+        {{cpp.registerSize(registers, field[key].register[12:])}} get{{key}}();
         {% endif %}
-        {% if 'W' is in(function[key].readWrite) %}
+        {% if 'W' is in(field[key].readWrite) %}
         /**
-{{utils.pad_string("         * ", function[key].description)}}
+{{utils.pad_string("         * ", field[key].description)}}
          */
         int set{{key}}(uint8_t data);
         {% endif %}
+        {% endfor %}
+        {% endfor %}
 
+        {% for function in functions %}
+        {% for key in function.keys() %}
         {% if function[key].computed %}
         {% for compute in function[key].computed %}
         {% for computeKey in compute.keys() %}

--- a/templates/kubos.c
+++ b/templates/kubos.c
@@ -122,53 +122,57 @@ int {{info.title.lower()}}_write{{key}}({{cpp.numtype(register[key].length)}}* d
 {% endfor %}
 {%- endfor %}
 
-{% for function in functions %}
-{% for key in function.keys() %}
-{% if 'R' is in(function[key].readWrite) %}
-{% set int_t = cpp.registerSize(registers, function[key].register[12:]) %}
+{% for field in fields %}
+{% for key in field.keys() %}
+{% if 'R' is in(field[key].readWrite) %}
+{% set int_t = cpp.registerSize(registers, field[key].register[12:]) %}
 {# Getter #}
 int {{info.title.lower()}}_get_{{key.lower()}}({{int_t}}* val) {
     // Read register data
-    // '#/registers/{{function[key].register[12:]}}' > '{{function[key].register[12:]}}'
-    int result = {{info.title.lower()}}_read{{function[key].register[12:]}}(val);
+    // '#/registers/{{field[key].register[12:]}}' > '{{field[key].register[12:]}}'
+    int result = {{info.title.lower()}}_read{{field[key].register[12:]}}(val);
     if (result != 0) {
         return result;
     }
     // Mask register value
-    val = val & {{utils.mask(function[key].bitStart, function[key].bitEnd)}};
-    {% if function[key].bitEnd %}
+    val = val & {{utils.mask(field[key].bitStart, field[key].bitEnd)}};
+    {% if field[key].bitEnd %}
     // Bitshift value
-    val = val >> {{function[key].bitEnd}};
+    val = val >> {{field[key].bitEnd}};
     {% endif %}
     return 0;
 }
 {% endif -%}
 
-{%- if 'W' is in(function[key].readWrite) %}
-{% set int_t = cpp.registerSize(registers, function[key].register[12:]) %}
+{%- if 'W' is in(field[key].readWrite) %}
+{% set int_t = cpp.registerSize(registers, field[key].register[12:]) %}
 {# Setter #}
 
 int {{info.title.lower()}}_set_{{key.lower()}}({{int_t}}* data) {
-    {% if function[key].bitEnd %}
+    {% if field[key].bitEnd %}
     // Bitshift value
-    data = data << {{function[key].bitEnd}};
+    data = data << {{field[key].bitEnd}};
     {% endif %}
     // Read current register data
-    // '#/registers/{{function[key].register[12:]}}' > '{{function[key].register[12:]}}'
+    // '#/registers/{{field[key].register[12:]}}' > '{{field[key].register[12:]}}'
     {{int_t}} register_data;
-    int result = {{info.title.lower()}}_read{{function[key].register[12:]}}(&register_data);
+    int result = {{info.title.lower()}}_read{{field[key].register[12:]}}(&register_data);
     if (result != 0) {
         return -1;
     }
     register_data = register_data | data;
-    result = {{info.title.lower()}}_write{{function[key].register[12:]}}(&register_data);
+    result = {{info.title.lower()}}_write{{field[key].register[12:]}}(&register_data);
     if (result != 0) {
         return -2;
     }
     return 0;
 }
 {% endif %}
+{% endfor %}
+{% endfor %}
 
+{% for function in functions %}
+{% for key in function.keys() %}
 {% if function[key].computed %}
 {% for compute in function[key].computed %}
 {% for computeKey in compute.keys() %}

--- a/templates/kubos.h
+++ b/templates/kubos.h
@@ -47,19 +47,19 @@
 {% endfor %}
 {% endfor %}
 
-{# Create enums for functions #}
-{% for function in functions %}
-{% for key in function.keys() %}
-{% if function[key].enum %}
+{# Create enums for fields #}
+{% for field in fields %}
+{% for key in field.keys() %}
+{% if field[key].enum %}
 {# Create enum #}
 /*
-{{utils.pad_string(" * ", "Valid values for " + function[key].title)}}
+{{utils.pad_string(" * ", "Valid values for " + field[key].title)}}
  */
 enum {{key}} {
     {% set args = namespace(index=0) %}
-    {% for enumObject in function[key].enum %}
+    {% for enumObject in field[key].enum %}
     {% for enumKey in enumObject.keys() %}
-    {{key.upper()}}_{{enumKey.upper()}} = {{enumObject[enumKey].value}}{{- "," if args.index + 1 < function[key].enum | length }} // {{enumObject[enumKey].title}}
+    {{key.upper()}}_{{enumKey.upper()}} = {{enumObject[enumKey].value}}{{- "," if args.index + 1 < field[key].enum | length }} // {{enumObject[enumKey].title}}
     {% set args.index = args.index + 1 %}
     {% endfor %}
     {% endfor %}
@@ -86,23 +86,27 @@ int {{info.title.lower()}}_write{{key}}({{cpp.numtype(register[key].length)}}* d
 {% endfor %}
 {%- endfor %}
 
-{% for function in functions %}
-{% for key in function.keys() %}
-{% if 'R' is in(function[key].readWrite) %}
-{% set int_t = cpp.registerSize(registers, function[key].register[12:]) %}
+{% for field in fields %}
+{% for key in field.keys() %}
+{% if 'R' is in(field[key].readWrite) %}
+{% set int_t = cpp.registerSize(registers, field[key].register[12:]) %}
 /**
-{{utils.pad_string(" * ", function[key].description)}}
+{{utils.pad_string(" * ", field[key].description)}}
  */
 int {{info.title.lower()}}_get_{{key.lower()}}({{int_t}}* val);
 {% endif %}
-{% if 'W' is in(function[key].readWrite) %}
-{% set int_t = cpp.registerSize(registers, function[key].register[12:]) %}
+{% if 'W' is in(field[key].readWrite) %}
+{% set int_t = cpp.registerSize(registers, field[key].register[12:]) %}
 /**
-{{utils.pad_string(" * ", function[key].description)}}
+{{utils.pad_string(" * ", field[key].description)}}
  */
 int {{info.title.lower()}}_set_{{key.lower()}}({{int_t}}* data);
 {% endif %}
+{% endfor %}
+{% endfor %}
 
+{% for function in functions %}
+{% for key in function.keys() %}
 {% if function[key].computed %}
 {% for compute in function[key].computed %}
 {% for computeKey in compute.keys() %}

--- a/templates/python.jinja2
+++ b/templates/python.jinja2
@@ -115,16 +115,20 @@
 {%- endfor %}
 {%- endmacro %}
 
-{% macro importStdLibs(functions, template) %}
-{% for function in functions %}
-{% for key in function.keys() %}
-{% if function[key].enum %}
+{% macro importStdLibs(fields, functions, template) %}
+{% for field in fields %}
+{% for key in field.keys() %}
+{% if field[key].enum %}
 {# Optionally import class #}
 {% if template.enum is sameas false %}
 from enum import Enum
 {% set template.enum = true %}
 {% endif %}
 {% endif %}
+{% endfor %}
+{% endfor %}
+{% for function in functions %}
+{% for key in function.keys() %}
 {# Check if we need to import `math` lib #}
 {% if function[key].computed %}
 {% for compute in function[key].computed %}

--- a/test/sampleData/ADS1015.cpp
+++ b/test/sampleData/ADS1015.cpp
@@ -126,7 +126,6 @@ int ADS1015::setSampleRate(uint8_t data) {
     return writeConfig(register_data);
 }
 
-
 int ADS1015::setProgrammableGain(uint8_t data) {
     // Bitshift value
     data = data << 9;
@@ -137,7 +136,6 @@ int ADS1015::setProgrammableGain(uint8_t data) {
     return writeConfig(register_data);
 }
 
-
 int ADS1015::setDeviceOperatingMode(uint8_t data) {
     // Bitshift value
     data = data << 8;
@@ -147,8 +145,6 @@ int ADS1015::setDeviceOperatingMode(uint8_t data) {
     register_data = register_data | data;
     return writeConfig(register_data);
 }
-
-
 
 short ADS1015::analogread(char channel) {
     short config; // Variable declaration

--- a/test/sampleData/ADS1015.h
+++ b/test/sampleData/ADS1015.h
@@ -106,24 +106,16 @@ class ADS1015 {
 
          */
         int setSampleRate(uint8_t data);
-
-
         /**
          * This sets the programmable gain for reading analog voltage
 
          */
         int setProgrammableGain(uint8_t data);
-
-
         /**
          * This bit controls the operating mode
 
          */
         int setDeviceOperatingMode(uint8_t data);
-
-
-
-
 
         /**
          * Reads the analog voltage in Volts

--- a/test/sampleData/BMP280.cpp
+++ b/test/sampleData/BMP280.cpp
@@ -707,7 +707,6 @@ float BMP280::temperatureasCelsius() {
     return celsius;
 }
 
-
 short BMP280::pressureasRaw() {
     char valueMsb; // Variable declaration
     char valueLsb; // Variable declaration

--- a/test/sampleData/BMP280.h
+++ b/test/sampleData/BMP280.h
@@ -242,7 +242,6 @@ class BMP280 {
          */
         float temperatureasCelsius();
 
-
         /**
          * Reads the atmospheric pressure
 

--- a/test/sampleData/LSM303D.cpp
+++ b/test/sampleData/LSM303D.cpp
@@ -489,7 +489,6 @@ void LSM303D::accelerationasG(short * returnArray) {
     returnArray[2] = valueZ;
 }
 
-
 short LSM303D::orientationxPlane() {
     char lower; // Variable declaration
     char upper; // Variable declaration

--- a/test/sampleData/LSM303D.h
+++ b/test/sampleData/LSM303D.h
@@ -187,7 +187,6 @@ class LSM303D {
          */
         void accelerationasG(short * returnArray);
 
-
         /**
          * Reads the magnetic orientation
 

--- a/test/sampleData/MCP4725.cpp
+++ b/test/sampleData/MCP4725.cpp
@@ -126,7 +126,6 @@ int MCP4725::setdigitalOut(uint8_t data) {
     return writeEEPROM(register_data);
 }
 
-
 void MCP4725::setVOutasVoltage(float vcc, float output) {
 
 
@@ -135,7 +134,6 @@ void MCP4725::setVOutasVoltage(float vcc, float output) {
 
 
 }
-
 
 float MCP4725::getVOutasVoltage(float vcc) {
     float voltage; // Variable declaration

--- a/test/sampleData/MCP4725.h
+++ b/test/sampleData/MCP4725.h
@@ -82,14 +82,11 @@ class MCP4725 {
          */
         int setdigitalOut(uint8_t data);
 
-
-
         /**
          * set vout
 
          */
         void setVOutasVoltage(float vcc, float output);
-
 
         /**
          * get vout

--- a/test/sampleData/MCP9808.cpp
+++ b/test/sampleData/MCP9808.cpp
@@ -73,7 +73,6 @@ uint16_t MCP9808::getlimitHysteresis() {
     val = val >> 9;
     return val;
 }
-
 uint16_t MCP9808::getshutdownMode() {
     // Read register data
     // '#/registers/configuration' > 'configuration'

--- a/test/sampleData/MCP9808.h
+++ b/test/sampleData/MCP9808.h
@@ -76,8 +76,6 @@ class MCP9808 {
 
          */
         uint16_t getlimitHysteresis();
-
-
         /**
          * In shutdown, all power-consuming activities are disabled, though
          * all registers can be written to or read. This bit cannot be set
@@ -87,7 +85,6 @@ class MCP9808 {
 
          */
         uint16_t getshutdownMode();
-
 
 
     private:

--- a/test/sampleData/TCS3472.h
+++ b/test/sampleData/TCS3472.h
@@ -108,7 +108,6 @@ class TCS3472 {
         int setinit(uint8_t data);
 
 
-
     private:
         TwoWire* _wire;
 };

--- a/test/sampleDataKubos/ADS1015.c
+++ b/test/sampleDataKubos/ADS1015.c
@@ -112,7 +112,6 @@ int ads1015_set_samplerate(uint16_t* data) {
     return 0;
 }
 
-
 int ads1015_set_programmablegain(uint16_t* data) {
     // Bitshift value
     data = data << 9;
@@ -131,7 +130,6 @@ int ads1015_set_programmablegain(uint16_t* data) {
     return 0;
 }
 
-
 int ads1015_set_deviceoperatingmode(uint16_t* data) {
     // Bitshift value
     data = data << 8;
@@ -149,8 +147,6 @@ int ads1015_set_deviceoperatingmode(uint16_t* data) {
     }
     return 0;
 }
-
-
 
 void ads1015_analog_read(short* val, ) {
     short config; // Variable declaration

--- a/test/sampleDataKubos/ADS1015.h
+++ b/test/sampleDataKubos/ADS1015.h
@@ -108,24 +108,16 @@ int ads1015_writeConversion(uint16_t* data);
 
  */
 int ads1015_set_samplerate(uint16_t* data);
-
-
 /**
  * This sets the programmable gain for reading analog voltage
 
  */
 int ads1015_set_programmablegain(uint16_t* data);
-
-
 /**
  * This bit controls the operating mode
 
  */
 int ads1015_set_deviceoperatingmode(uint16_t* data);
-
-
-
-
 
 /**
  * Reads the analog voltage in Volts

--- a/test/sampleDataKubos/BMP280.c
+++ b/test/sampleDataKubos/BMP280.c
@@ -505,7 +505,6 @@ void bmp280_temperature_ascelsius(float* val) {
     return celsius;
 }
 
-
 void bmp280_pressure_asraw(short* val) {
     char valueMsb; // Variable declaration
     char valueLsb; // Variable declaration

--- a/test/sampleDataKubos/BMP280.h
+++ b/test/sampleDataKubos/BMP280.h
@@ -260,7 +260,6 @@ void bmp280_temperature_asraw(short* val);
 */
 void bmp280_temperature_ascelsius(float* val);
 
-
 /**
  * Reads the atmospheric pressure
 

--- a/test/sampleDataKubos/LSM303D.c
+++ b/test/sampleDataKubos/LSM303D.c
@@ -369,7 +369,6 @@ void lsm303d_acceleration_asg(void* val) {
     return [value_x, value_y, value_z];
 }
 
-
 void lsm303d_orientation_xplane(short* val) {
     char lower; // Variable declaration
     char upper; // Variable declaration

--- a/test/sampleDataKubos/LSM303D.h
+++ b/test/sampleDataKubos/LSM303D.h
@@ -199,7 +199,6 @@ void lsm303d_acceleration_zplane(short* val);
 */
 void lsm303d_acceleration_asg(void* val);
 
-
 /**
  * Reads the magnetic orientation
 

--- a/test/sampleDataKubos/MCP4725.c
+++ b/test/sampleDataKubos/MCP4725.c
@@ -119,7 +119,6 @@ int mcp4725_set_digitalout(uint16_t* data) {
     return 0;
 }
 
-
 void mcp4725_setvout_asvoltage(void* val, ) {
 
 
@@ -129,7 +128,6 @@ void mcp4725_setvout_asvoltage(void* val, ) {
 
     return [];
 }
-
 
 void mcp4725_getvout_asvoltage(float* val, ) {
     float voltage; // Variable declaration

--- a/test/sampleDataKubos/MCP4725.h
+++ b/test/sampleDataKubos/MCP4725.h
@@ -84,14 +84,11 @@ int mcp4725_get_digitalout(uint16_t* val);
  */
 int mcp4725_set_digitalout(uint16_t* data);
 
-
-
 /**
  * set vout
 
 */
 void mcp4725_setvout_asvoltage(void* val, );
-
 
 /**
  * get vout

--- a/test/sampleDataKubos/MCP9808.c
+++ b/test/sampleDataKubos/MCP9808.c
@@ -66,7 +66,6 @@ int mcp9808_get_limithysteresis(uint16_t* val) {
     val = val >> 9;
     return 0;
 }
-
 int mcp9808_get_shutdownmode(uint16_t* val) {
     // Read register data
     // '#/registers/configuration' > 'configuration'

--- a/test/sampleDataKubos/MCP9808.h
+++ b/test/sampleDataKubos/MCP9808.h
@@ -77,8 +77,6 @@ int mcp9808_writeconfiguration(uint16_t* data);
 
  */
 int mcp9808_get_limithysteresis(uint16_t* val);
-
-
 /**
  * In shutdown, all power-consuming activities are disabled, though
  * all registers can be written to or read. This bit cannot be set
@@ -88,7 +86,6 @@ int mcp9808_get_limithysteresis(uint16_t* val);
 
  */
 int mcp9808_get_shutdownmode(uint16_t* val);
-
 
 
 #endif

--- a/test/sampleDataKubos/TCS3472.h
+++ b/test/sampleDataKubos/TCS3472.h
@@ -113,5 +113,4 @@ int tcs3472_get_init(uint8_t* val);
 int tcs3472_set_init(uint8_t* data);
 
 
-
 #endif


### PR DESCRIPTION
Creates a separate fields attribute to represent properties
like enums and subsets of a register. This creates some
modifications that have to be made to the templates, which
creates some spacing improvements in sample code. This also
allows the schema to become more precise.

Fixes #9
Fixes #86