### PR TITLE
Add support for peripherals that can have more than one device address

### DIFF
--- a/peripherals/MCP9808.yaml
+++ b/peripherals/MCP9808.yaml
@@ -15,7 +15,15 @@ info:
     version: 0.1.0
 i2c:
     addressType: '7-bit'
-    address: 0x18
+    address:
+        - 0x18
+        - 0x19
+        - 0x1A
+        - 0x1B
+        - 0x1C
+        - 0x1D
+        - 0x1E
+        - 0x1F
     addressMask: 0x78
 
 registers:

--- a/spec/cyanobyte.schema.json
+++ b/spec/cyanobyte.schema.json
@@ -118,7 +118,16 @@
         },
         "address": {
           "description": "I2C Address of the component",
-          "type": "integer"
+          "oneOf": [
+            {"type": "integer"},
+            {
+              "type": "array",
+              "items": {
+                "description": "Array of potentially valid device addresses",
+                "type": "integer"
+              }
+            }
+          ]
         },
         "addressMask": {
           "description": "Address mask for addresses that can be altered",

--- a/templates/arduino.cpp
+++ b/templates/arduino.cpp
@@ -69,7 +69,9 @@ static short _sign(short val, char length) {
 {% endfor %}
 
 #include "{{info.title}}.h"
+{% if i2c.address is number %}
 #define DEVICE_ADDRESS {{i2c.address}}
+{% endif %}
 
 {% for register in registers %}
 {% for key in register.keys() %}
@@ -77,10 +79,18 @@ static short _sign(short val, char length) {
 {% endfor %}
 {% endfor %}
 
+{% if i2c.address is iterable and i2c.address is not string %}
+{{info.title}}::{{info.title}}(TwoWire& wire, deviceAddress_t address) :
+    _wire(&wire),
+    DEVICE_ADDRESS ( address )
+{
+}
+{% else %}
 {{info.title}}::{{info.title}}(TwoWire& wire) :
     _wire(&wire)
 {
 }
+{% endif %}
 
 void {{info.title}}::begin() {
     _wire->begin();

--- a/templates/arduino.h
+++ b/templates/arduino.h
@@ -63,10 +63,23 @@ typedef enum {{key}} {{key}}_t;
 {% endif %}
 {% endfor %}
 {% endfor %}
+{% if i2c.address is iterable and i2c.address is not string %}
+enum deviceAddress {
+    {% for address in i2c.address %}
+    I2C_ADDRESS_{{address}} = {{address}}{{ "," if not loop.last }}
+    {% endfor %}
+};
+typedef enum deviceAddress deviceAddress_t;
+{% endif %}
 
 class {{info.title}} {
     public:
+        {% if i2c.address is iterable and i2c.address is not string %}
+        {{info.title}}(TwoWire& wire, deviceAddress_t address);
+        deviceAddress_t DEVICE_ADDRESS;
+        {% else %}
         {{info.title}}(TwoWire& wire);
+        {% endif %}
 
         void begin();
         void end();

--- a/templates/cmsis.svd
+++ b/templates/cmsis.svd
@@ -20,7 +20,11 @@
         <peripheral>
             <name>{{ info.title }}</name>
             <description>{{ info.description }}</description>
+            {% if i2c.address is iterable and i2c.address is not string %}
+            <baseAddress>{{ i2c.address[0] }}</baseAddress>
+            {% else %}
             <baseAddress>{{ i2c.address }}</baseAddress>
+            {% endif %}
             <addressBlock>
                 <offset>0</offset>
                 <size>{{ i2c.addressMask }}</size>

--- a/templates/datasheet.tex
+++ b/templates/datasheet.tex
@@ -37,7 +37,14 @@
 \section{Overview}
     {{ info.description }}
     \begin{itemize}
+        {% if i2c.address is iterable and i2c.address is not string %}
+        \item Device addresses:
+          {% for address in i2c.address %}
+          {{address}}{{ "," if not loop.last }}
+          {% endfor %}
+        {% else %}
         \item Device address {{ i2c.address }}
+        {% endif %}
         \item Address type {{ i2c.addressType }}
         {% if i2c.endian == 'little' %}
         \item Little Endian

--- a/templates/generic.c
+++ b/templates/generic.c
@@ -70,7 +70,9 @@ static short _sign(short val, short length) {
 {% endfor %}
 
 #include "{{info.title}}.h"
+{% if i2c.address is number %}
 #define DEVICE_ADDRESS {{i2c.address}}
+{% endif %}
 
 {% for register in registers %}
 {% for key in register.keys() %}
@@ -79,12 +81,24 @@ static short _sign(short val, short length) {
 {% endfor %}
 
 // Provide an I2C connect function, return status
+{% if i2c.address is iterable and i2c.address is not string %}
+static deviceAddress_t DEVICE_ADDRESS;
+
+int {{info.title.lower()}}_init(deviceAddress_t address, int (*connect)(uint8_t)) {
+    DEVICE_ADDRESS = address;
+    // Initialize bus
+    if (connect(DEVICE_ADDRESS) != 0) {
+        return -1;
+    }
+}
+{% else %}
 int {{info.title.lower()}}_init(int (*connect)(uint8_t)) {
     // Initialize bus
     if (connect(DEVICE_ADDRESS) != 0) {
         return -1;
     }
 }
+{% endif %}
 
 {% for register in registers -%}
 {% for key in register.keys() %}

--- a/templates/generic.h
+++ b/templates/generic.h
@@ -64,8 +64,20 @@ typedef enum {{key}} {{key}}_t;
 {% endif %}
 {% endfor %}
 {% endfor %}
+{% if i2c.address is iterable and i2c.address is not string %}
+enum deviceAddress {
+    {% for address in i2c.address %}
+    I2C_ADDRESS_{{address}} = {{address}}{{ "," if not loop.last }}
+    {% endfor %}
+};
+typedef enum deviceAddress deviceAddress_t;
+{% endif %}
 
-int {{info.title.lower()}}_init(char* bus_name, int (*connect)(uint8_t));
+{% if i2c.address is iterable and i2c.address is not string %}
+int {{info.title.lower()}}_init(deviceAddress_t address, int (*connect)(uint8_t));
+{% else %}
+int {{info.title.lower()}}_init(int (*connect)(uint8_t));
+{% endif %}
 {% for register in registers -%}
 {% for key in register.keys() %}
 {% set length = (register[key].length / 8) | round(1, 'ceil') | int %}   

--- a/templates/kubos.c
+++ b/templates/kubos.c
@@ -70,7 +70,9 @@ short _sign(val, length) {
 {% endfor %}
 
 #include "{{info.title}}.h"
+{% if i2c.address is number %}
 #define DEVICE_ADDRESS {{i2c.address}}
+{% endif %}
 
 {% for register in registers %}
 {% for key in register.keys() %}
@@ -82,12 +84,24 @@ static int i2c_bus = 0; // Pointer to bus
 
 // Provide `bus_name` based on application specifics.
 // For example, you may pass in bus name "/dev/i2c-1"
+{% if i2c.address is iterable and i2c.address is not string %}
+static deviceAddress_t DEVICE_ADDRESS;
+
+int {{info.title.lower()}}_init(deviceAddress_t address, char* bus_name) {
+    DEVICE_ADDRESS = address;
+    // Initialize bus
+    if (k_i2c_init(&bus_name, &i2c_bus) != I2C_OK) {
+        return -1;
+    }
+}
+{% else %}
 int {{info.title.lower()}}_init(char* bus_name) {
     // Initialize bus
     if (k_i2c_init(&bus_name, &i2c_bus) != I2C_OK) {
         return -1;
     }
 }
+{% endif %}
 
 void {{info.title.lower()}}_terminate() {
     k_i2c_terminate(&i2c_bus);

--- a/templates/kubos.h
+++ b/templates/kubos.h
@@ -66,8 +66,20 @@ typedef enum {{key}} {{key}}_t;
 {% endif %}
 {% endfor %}
 {% endfor %}
+{% if i2c.address is iterable and i2c.address is not string %}
+enum deviceAddress {
+    {% for address in i2c.address %}
+    I2C_ADDRESS_{{address}} = {{address}}{{ "," if not loop.last }}
+    {% endfor %}
+};
+typedef enum deviceAddress deviceAddress_t;
+{% endif %}
 
+{% if i2c.address is iterable and i2c.address is not string %}
+int {{info.title.lower()}}_init(deviceAddress_t address, char* bus_name);
+{% else %}
 int {{info.title.lower()}}_init(char* bus_name);
+{% endif %}
 void {{info.title.lower()}}_terminate();
 {% for register in registers -%}
 {% for key in register.keys() %}

--- a/templates/raspberrypi.py
+++ b/templates/raspberrypi.py
@@ -104,7 +104,7 @@ class {{ info.title }}:
 {{utils.pad_string("    ", info.description)}}
     """
     {% if i2c.address is number %}
-    DEVICE_ADDRESS = {{i2c.address}}
+    device_address = {{i2c.address}}
     {% endif %}
     {% for register in registers %}
     {% for key in register.keys() %}
@@ -116,7 +116,7 @@ class {{ info.title }}:
     def __init__(self, address):
         # Initialize connection to peripheral
         self.bus = smbus.SMBus(1)
-        self.DEVICE_ADDRESS = address
+        self.device_address = address
     {% else %}
     def __init__(self):
         # Initialize connection to peripheral
@@ -131,12 +131,12 @@ class {{ info.title }}:
         """
         {% if register[key].length <= 8 %}
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_{{key.upper()}}
         )
         {% elif register[key].length <= 16 %}
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_{{key.upper()}}
         )
         {% endif %}
@@ -158,13 +158,13 @@ class {{ info.title }}:
         {% endif %}
         {% if register[key].length <= 8 %}
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_{{key.upper()}},
             data
         )
         {% elif register[key].length <= 16 %}
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_{{key.upper()}},
             data
         )

--- a/templates/raspberrypi.py
+++ b/templates/raspberrypi.py
@@ -62,6 +62,15 @@ class {{key[0].upper()}}{{key[1:]}}Values(Enum):
 {% endif %}
 {% endfor %}
 {% endfor %}
+{% if i2c.address is iterable and i2c.address is not string %}
+class DeviceAddressValues(Enum):
+    """
+    Valid device addresses
+    """
+    {% for address in i2c.address %}
+    I2C_ADDRESS_{{address}} = {{address}}
+    {% endfor %}
+{% endif %}
 
 {% if i2c.endian == 'little' %}
 def _swap_endian(val):
@@ -94,16 +103,25 @@ class {{ info.title }}:
     """
 {{utils.pad_string("    ", info.description)}}
     """
+    {% if i2c.address is number %}
     DEVICE_ADDRESS = {{i2c.address}}
+    {% endif %}
     {% for register in registers %}
     {% for key in register.keys() %}
     REGISTER_{{key.upper()}} = {{register[key].address}}
     {% endfor %}
     {% endfor %}
 
+    {% if i2c.address is iterable and i2c.address is not string %}
+    def __init__(self, address):
+        # Initialize connection to peripheral
+        self.bus = smbus.SMBus(1)
+        self.DEVICE_ADDRESS = address
+    {% else %}
     def __init__(self):
         # Initialize connection to peripheral
         self.bus = smbus.SMBus(1)
+    {% endif %}
 
     {% for register in registers -%}
     {% for key in register.keys() %}

--- a/test/sampleData/arduino/MCP9808.cpp
+++ b/test/sampleData/arduino/MCP9808.cpp
@@ -24,12 +24,12 @@
 
 
 #include "MCP9808.h"
-#define DEVICE_ADDRESS 24
 
 #define REGISTER_CONFIGURATION 1
 
-MCP9808::MCP9808(TwoWire& wire) :
-    _wire(&wire)
+MCP9808::MCP9808(TwoWire& wire, deviceAddress_t address) :
+    _wire(&wire),
+    DEVICE_ADDRESS ( address )
 {
 }
 

--- a/test/sampleData/arduino/MCP9808.h
+++ b/test/sampleData/arduino/MCP9808.h
@@ -45,10 +45,22 @@ enum shutdownMode {
     SHUTDOWNMODE_SHUTDOWN = 1 // Shutdown (Low-Power mode)
 };
 typedef enum shutdownMode shutdownMode_t;
+enum deviceAddress {
+    I2C_ADDRESS_24 = 24,
+    I2C_ADDRESS_25 = 25,
+    I2C_ADDRESS_26 = 26,
+    I2C_ADDRESS_27 = 27,
+    I2C_ADDRESS_28 = 28,
+    I2C_ADDRESS_29 = 29,
+    I2C_ADDRESS_30 = 30,
+    I2C_ADDRESS_31 = 31
+};
+typedef enum deviceAddress deviceAddress_t;
 
 class MCP9808 {
     public:
-        MCP9808(TwoWire& wire);
+        MCP9808(TwoWire& wire, deviceAddress_t address);
+        deviceAddress_t DEVICE_ADDRESS;
 
         void begin();
         void end();

--- a/test/sampleData/datasheet/MCP9808.tex
+++ b/test/sampleData/datasheet/MCP9808.tex
@@ -36,7 +36,15 @@
 \section{Overview}
     This is a test description
     \begin{itemize}
-        \item Device address 24
+        \item Device addresses:
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30,
+          31
         \item Address type 7-bit
     \end{itemize}
 

--- a/test/sampleData/embedded-c/ADS1015.h
+++ b/test/sampleData/embedded-c/ADS1015.h
@@ -72,7 +72,7 @@ enum Channel {
 };
 typedef enum Channel Channel_t;
 
-int ads1015_init(char* bus_name, int (*connect)(uint8_t));
+int ads1015_init(int (*connect)(uint8_t));
    
 /**
   * Describes the specifics of the sensing implementation

--- a/test/sampleData/embedded-c/BMP280.h
+++ b/test/sampleData/embedded-c/BMP280.h
@@ -25,7 +25,7 @@
 
 
 
-int bmp280_init(char* bus_name, int (*connect)(uint8_t));
+int bmp280_init(int (*connect)(uint8_t));
    
 /**
   * Part 1 of temperature

--- a/test/sampleData/embedded-c/LSM303D.h
+++ b/test/sampleData/embedded-c/LSM303D.h
@@ -26,7 +26,7 @@
 #include <math.h>
 
 
-int lsm303d_init(char* bus_name, int (*connect)(uint8_t));
+int lsm303d_init(int (*connect)(uint8_t));
    
 /**
   * Raw accelerometer data on X plane

--- a/test/sampleData/embedded-c/MCP4725.h
+++ b/test/sampleData/embedded-c/MCP4725.h
@@ -34,7 +34,7 @@ enum digitalOut {
 };
 typedef enum digitalOut digitalOut_t;
 
-int mcp4725_init(char* bus_name, int (*connect)(uint8_t));
+int mcp4725_init(int (*connect)(uint8_t));
    
 /**
   * VOut = (Vcc * value) / 4096

--- a/test/sampleData/embedded-c/MCP9808.c
+++ b/test/sampleData/embedded-c/MCP9808.c
@@ -24,12 +24,14 @@
 
 
 #include "MCP9808.h"
-#define DEVICE_ADDRESS 24
 
 #define REGISTER_CONFIGURATION 1
 
 // Provide an I2C connect function, return status
-int mcp9808_init(int (*connect)(uint8_t)) {
+static deviceAddress_t DEVICE_ADDRESS;
+
+int mcp9808_init(deviceAddress_t address, int (*connect)(uint8_t)) {
+    DEVICE_ADDRESS = address;
     // Initialize bus
     if (connect(DEVICE_ADDRESS) != 0) {
         return -1;

--- a/test/sampleData/embedded-c/MCP9808.h
+++ b/test/sampleData/embedded-c/MCP9808.h
@@ -44,8 +44,19 @@ enum shutdownMode {
     SHUTDOWNMODE_SHUTDOWN = 1 // Shutdown (Low-Power mode)
 };
 typedef enum shutdownMode shutdownMode_t;
+enum deviceAddress {
+    I2C_ADDRESS_24 = 24,
+    I2C_ADDRESS_25 = 25,
+    I2C_ADDRESS_26 = 26,
+    I2C_ADDRESS_27 = 27,
+    I2C_ADDRESS_28 = 28,
+    I2C_ADDRESS_29 = 29,
+    I2C_ADDRESS_30 = 30,
+    I2C_ADDRESS_31 = 31
+};
+typedef enum deviceAddress deviceAddress_t;
 
-int mcp9808_init(char* bus_name, int (*connect)(uint8_t));
+int mcp9808_init(deviceAddress_t address, int (*connect)(uint8_t));
    
 /**
   * The MCP9808 has a 16-bit Configuration register (CONFIG) that

--- a/test/sampleData/embedded-c/TCS3472.h
+++ b/test/sampleData/embedded-c/TCS3472.h
@@ -34,7 +34,7 @@ enum init {
 };
 typedef enum init init_t;
 
-int tcs3472_init(char* bus_name, int (*connect)(uint8_t));
+int tcs3472_init(int (*connect)(uint8_t));
    
 /**
   * Enable specific components of the peripheral

--- a/test/sampleData/kubos/MCP9808.c
+++ b/test/sampleData/kubos/MCP9808.c
@@ -24,7 +24,6 @@
 
 
 #include "MCP9808.h"
-#define DEVICE_ADDRESS 24
 
 #define REGISTER_CONFIGURATION 1
 
@@ -32,7 +31,10 @@ static int i2c_bus = 0; // Pointer to bus
 
 // Provide `bus_name` based on application specifics.
 // For example, you may pass in bus name "/dev/i2c-1"
-int mcp9808_init(char* bus_name) {
+static deviceAddress_t DEVICE_ADDRESS;
+
+int mcp9808_init(deviceAddress_t address, char* bus_name) {
+    DEVICE_ADDRESS = address;
     // Initialize bus
     if (k_i2c_init(&bus_name, &i2c_bus) != I2C_OK) {
         return -1;

--- a/test/sampleData/kubos/MCP9808.h
+++ b/test/sampleData/kubos/MCP9808.h
@@ -48,8 +48,19 @@ enum shutdownMode {
     SHUTDOWNMODE_SHUTDOWN = 1 // Shutdown (Low-Power mode)
 };
 typedef enum shutdownMode shutdownMode_t;
+enum deviceAddress {
+    I2C_ADDRESS_24 = 24,
+    I2C_ADDRESS_25 = 25,
+    I2C_ADDRESS_26 = 26,
+    I2C_ADDRESS_27 = 27,
+    I2C_ADDRESS_28 = 28,
+    I2C_ADDRESS_29 = 29,
+    I2C_ADDRESS_30 = 30,
+    I2C_ADDRESS_31 = 31
+};
+typedef enum deviceAddress deviceAddress_t;
 
-int mcp9808_init(char* bus_name);
+int mcp9808_init(deviceAddress_t address, char* bus_name);
 void mcp9808_terminate();
    
 /**

--- a/test/sampleData/raspberrypi/ADS1015.py
+++ b/test/sampleData/raspberrypi/ADS1015.py
@@ -73,7 +73,7 @@ class ADS1015:
     Texas Instruments Analog-Digital Converter
 
     """
-    DEVICE_ADDRESS = 73
+    device_address = 73
     REGISTER_CONFIG = 1
     REGISTER_CONVERSION = 0
 
@@ -87,7 +87,7 @@ class ADS1015:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_CONFIG
         )
         val = _swap_endian(val)
@@ -100,7 +100,7 @@ class ADS1015:
         """
         data = _swap_endian(data)
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_CONFIG,
             data
         )
@@ -110,7 +110,7 @@ class ADS1015:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_CONVERSION
         )
         val = _swap_endian(val)
@@ -123,7 +123,7 @@ class ADS1015:
         """
         data = _swap_endian(data)
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_CONVERSION,
             data
         )

--- a/test/sampleData/raspberrypi/BMP280.py
+++ b/test/sampleData/raspberrypi/BMP280.py
@@ -35,7 +35,7 @@ class BMP280:
     Bosch Digital Pressure Sensor
 
     """
-    DEVICE_ADDRESS = 119
+    device_address = 119
     REGISTER_TEMPMSB = 250
     REGISTER_TEMPLSB = 251
     REGISTER_TEMPXLSB = 252
@@ -65,7 +65,7 @@ class BMP280:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_TEMPMSB
         )
         return val
@@ -76,7 +76,7 @@ class BMP280:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_TEMPMSB,
             data
         )
@@ -86,7 +86,7 @@ class BMP280:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_TEMPLSB
         )
         return val
@@ -97,7 +97,7 @@ class BMP280:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_TEMPLSB,
             data
         )
@@ -107,7 +107,7 @@ class BMP280:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_TEMPXLSB
         )
         return val
@@ -118,7 +118,7 @@ class BMP280:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_TEMPXLSB,
             data
         )
@@ -128,7 +128,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGT1
         )
         return val
@@ -139,7 +139,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGT1,
             data
         )
@@ -149,7 +149,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGT2
         )
         return val
@@ -160,7 +160,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGT2,
             data
         )
@@ -170,7 +170,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGT3
         )
         # Unsigned > Signed integer
@@ -183,7 +183,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGT3,
             data
         )
@@ -193,7 +193,7 @@ class BMP280:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_PRESSUREMSB
         )
         return val
@@ -204,7 +204,7 @@ class BMP280:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_PRESSUREMSB,
             data
         )
@@ -214,7 +214,7 @@ class BMP280:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_PRESSURELSB
         )
         return val
@@ -225,7 +225,7 @@ class BMP280:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_PRESSURELSB,
             data
         )
@@ -235,7 +235,7 @@ class BMP280:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_PRESSUREXLSB
         )
         return val
@@ -246,7 +246,7 @@ class BMP280:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_PRESSUREXLSB,
             data
         )
@@ -256,7 +256,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP1
         )
         return val
@@ -267,7 +267,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP1,
             data
         )
@@ -277,7 +277,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP2
         )
         # Unsigned > Signed integer
@@ -290,7 +290,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP2,
             data
         )
@@ -300,7 +300,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP3
         )
         # Unsigned > Signed integer
@@ -313,7 +313,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP3,
             data
         )
@@ -323,7 +323,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP4
         )
         # Unsigned > Signed integer
@@ -336,7 +336,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP4,
             data
         )
@@ -346,7 +346,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP5
         )
         # Unsigned > Signed integer
@@ -359,7 +359,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP5,
             data
         )
@@ -369,7 +369,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP6
         )
         # Unsigned > Signed integer
@@ -382,7 +382,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP6,
             data
         )
@@ -392,7 +392,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP7
         )
         # Unsigned > Signed integer
@@ -405,7 +405,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP7,
             data
         )
@@ -415,7 +415,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP8
         )
         # Unsigned > Signed integer
@@ -428,7 +428,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP8,
             data
         )
@@ -438,7 +438,7 @@ class BMP280:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP9
         )
         # Unsigned > Signed integer
@@ -451,7 +451,7 @@ class BMP280:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_DIGP9,
             data
         )

--- a/test/sampleData/raspberrypi/LSM303D.py
+++ b/test/sampleData/raspberrypi/LSM303D.py
@@ -30,7 +30,7 @@ class LSM303D:
     STMicroelectronics accelerometer and magnetometer
 
     """
-    DEVICE_ADDRESS = 29
+    device_address = 29
     REGISTER_ACCELEROMETERX_LOW = 168
     REGISTER_ACCELEROMETERX_HIGH = 169
     REGISTER_ACCELEROMETERY_LOW = 170
@@ -54,7 +54,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERX_LOW
         )
         return val
@@ -65,7 +65,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERX_LOW,
             data
         )
@@ -75,7 +75,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERX_HIGH
         )
         return val
@@ -86,7 +86,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERX_HIGH,
             data
         )
@@ -96,7 +96,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERY_LOW
         )
         return val
@@ -107,7 +107,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERY_LOW,
             data
         )
@@ -117,7 +117,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERY_HIGH
         )
         return val
@@ -128,7 +128,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERY_HIGH,
             data
         )
@@ -138,7 +138,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERZ_LOW
         )
         return val
@@ -149,7 +149,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERZ_LOW,
             data
         )
@@ -159,7 +159,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERZ_HIGH
         )
         return val
@@ -170,7 +170,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ACCELEROMETERZ_HIGH,
             data
         )
@@ -180,7 +180,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERX_LOW
         )
         return val
@@ -191,7 +191,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERX_LOW,
             data
         )
@@ -201,7 +201,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERX_HIGH
         )
         return val
@@ -212,7 +212,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERX_HIGH,
             data
         )
@@ -222,7 +222,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERY_LOW
         )
         return val
@@ -233,7 +233,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERY_LOW,
             data
         )
@@ -243,7 +243,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERY_HIGH
         )
         return val
@@ -254,7 +254,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERY_HIGH,
             data
         )
@@ -264,7 +264,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERZ_LOW
         )
         return val
@@ -275,7 +275,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERZ_LOW,
             data
         )
@@ -285,7 +285,7 @@ class LSM303D:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERZ_HIGH
         )
         return val
@@ -296,7 +296,7 @@ class LSM303D:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_MAGNETOMETERZ_HIGH,
             data
         )

--- a/test/sampleData/raspberrypi/MCP4725.py
+++ b/test/sampleData/raspberrypi/MCP4725.py
@@ -41,7 +41,7 @@ class MCP4725:
     Microchip 4725 Digital-to-Analog Converter
 
     """
-    DEVICE_ADDRESS = 98
+    device_address = 98
     REGISTER_VOUT = 64
     REGISTER_EEPROM = 96
 
@@ -58,7 +58,7 @@ class MCP4725:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_VOUT
         )
         val = _swap_endian(val)
@@ -74,7 +74,7 @@ class MCP4725:
         """
         data = _swap_endian(data)
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_VOUT,
             data
         )
@@ -85,7 +85,7 @@ class MCP4725:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_EEPROM
         )
         val = _swap_endian(val)
@@ -99,7 +99,7 @@ class MCP4725:
         """
         data = _swap_endian(data)
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_EEPROM,
             data
         )

--- a/test/sampleData/raspberrypi/MCP9808.py
+++ b/test/sampleData/raspberrypi/MCP9808.py
@@ -37,6 +37,18 @@ class ShutdownModeValues(Enum):
     """
     CONTINOUSCONVERSION = 0 # Continuous conversion (power-up default)
     SHUTDOWN = 1 # Shutdown (Low-Power mode)
+class DeviceAddressValues(Enum):
+    """
+    Valid device addresses
+    """
+    I2C_ADDRESS_24 = 24
+    I2C_ADDRESS_25 = 25
+    I2C_ADDRESS_26 = 26
+    I2C_ADDRESS_27 = 27
+    I2C_ADDRESS_28 = 28
+    I2C_ADDRESS_29 = 29
+    I2C_ADDRESS_30 = 30
+    I2C_ADDRESS_31 = 31
 
 
 
@@ -45,12 +57,12 @@ class MCP9808:
     This is a test description
 
     """
-    DEVICE_ADDRESS = 24
     REGISTER_CONFIGURATION = 1
 
-    def __init__(self):
+    def __init__(self, address):
         # Initialize connection to peripheral
         self.bus = smbus.SMBus(1)
+        self.DEVICE_ADDRESS = address
 
     def get_configuration(self):
         """

--- a/test/sampleData/raspberrypi/MCP9808.py
+++ b/test/sampleData/raspberrypi/MCP9808.py
@@ -62,7 +62,7 @@ class MCP9808:
     def __init__(self, address):
         # Initialize connection to peripheral
         self.bus = smbus.SMBus(1)
-        self.DEVICE_ADDRESS = address
+        self.device_address = address
 
     def get_configuration(self):
         """
@@ -80,7 +80,7 @@ class MCP9808:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_CONFIGURATION
         )
         return val
@@ -101,7 +101,7 @@ class MCP9808:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_CONFIGURATION,
             data
         )

--- a/test/sampleData/raspberrypi/TCS3472.py
+++ b/test/sampleData/raspberrypi/TCS3472.py
@@ -36,7 +36,7 @@ class TCS3472:
     Color Light-to-Digital Converter with IR Filter
 
     """
-    DEVICE_ADDRESS = 41
+    device_address = 41
     REGISTER_ENABLE = 128
     REGISTER_CLEAR = 180
     REGISTER_RED = 182
@@ -53,7 +53,7 @@ class TCS3472:
 
         """
         val = self.bus.read_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ENABLE
         )
         return val
@@ -64,7 +64,7 @@ class TCS3472:
 
         """
         self.bus.write_byte_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_ENABLE,
             data
         )
@@ -74,7 +74,7 @@ class TCS3472:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_CLEAR
         )
         return val
@@ -85,7 +85,7 @@ class TCS3472:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_CLEAR,
             data
         )
@@ -95,7 +95,7 @@ class TCS3472:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_RED
         )
         return val
@@ -106,7 +106,7 @@ class TCS3472:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_RED,
             data
         )
@@ -116,7 +116,7 @@ class TCS3472:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_GREEN
         )
         return val
@@ -127,7 +127,7 @@ class TCS3472:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_GREEN,
             data
         )
@@ -137,7 +137,7 @@ class TCS3472:
 
         """
         val = self.bus.read_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_BLUE
         )
         return val
@@ -148,7 +148,7 @@ class TCS3472:
 
         """
         self.bus.write_word_data(
-            self.DEVICE_ADDRESS,
+            self.device_address,
             self.REGISTER_BLUE,
             data
         )


### PR DESCRIPTION
i2c.address field can be an array of numbers
Updated templates to support behavior
Fixed small bug in generic c template

Fixes #60