### PR TITLE
Add special function that runs on construction

### DIFF
--- a/peripherals/TCS3472.yaml
+++ b/peripherals/TCS3472.yaml
@@ -75,3 +75,20 @@ fields:
       RGBC:
         title: Color
         value: 0b10
+
+functions:
+  init:
+    title: Code to run when device class is constructed
+    description: Enables features on device
+    register: '#/registers/enable'
+    computed:
+      onCreate:
+        variables:
+          enables: int8
+        logic:
+          # Enable register = ENABLE_RGBC | ENABLE_POWER
+          - enables:
+            - sum:
+              - 1
+              - 0b10
+          - send: enables

--- a/templates/arduino.cpp
+++ b/templates/arduino.cpp
@@ -90,6 +90,9 @@ static short _sign(short val, char length) {
 
 void {{info.title}}::begin() {
     _wire->begin();
+    {% if 'init' in functions and 'onCreate' in functions.init.computed %}
+    initonCreate();
+    {% endif %}
 }
 
 void {{info.title}}::end() {

--- a/templates/kubos.c
+++ b/templates/kubos.c
@@ -89,6 +89,9 @@ int {{info.title.lower()}}_init(deviceAddress_t address, char* bus_name) {
     if (k_i2c_init(&bus_name, &i2c_bus) != I2C_OK) {
         return -1;
     }
+    {% if 'init' in functions and 'onCreate' in functions.init.computed %}
+    {{info.title.lower()}}_init_oncreate();
+    {% endif %}
 }
 {% else %}
 int {{info.title.lower()}}_init(char* bus_name) {
@@ -96,6 +99,9 @@ int {{info.title.lower()}}_init(char* bus_name) {
     if (k_i2c_init(&bus_name, &i2c_bus) != I2C_OK) {
         return -1;
     }
+    {% if 'init' in functions and 'onCreate' in functions.init.computed %}
+    {{info.title.lower()}}_init_oncreate();
+    {% endif %}
 }
 {% endif %}
 

--- a/templates/raspberrypi.py
+++ b/templates/raspberrypi.py
@@ -116,6 +116,9 @@ class {{ info.title }}:
         # Initialize connection to peripheral
         self.bus = smbus.SMBus(1)
     {% endif %}
+        {% if 'init' in functions and 'onCreate' in functions.init.computed %}
+        self.init_oncreate()
+        {% endif %}
 
     {% for key,register in registers|dictsort %}
     {% if (not 'readWrite' in register) or ('readWrite' in register and 'R' is in(register.readWrite)) %}

--- a/test/sampleData/arduino/TCS3472.cpp
+++ b/test/sampleData/arduino/TCS3472.cpp
@@ -39,6 +39,7 @@ TCS3472::TCS3472(TwoWire& wire) :
 
 void TCS3472::begin() {
     _wire->begin();
+    initonCreate();
 }
 
 void TCS3472::end() {
@@ -174,5 +175,15 @@ int TCS3472::setinit(uint8_t data) {
     uint8_t register_data = readenable();
     register_data = register_data | data;
     return writeenable(register_data);
+}
+
+void TCS3472::initonCreate() {
+    char enables; // Variable declaration
+
+
+    enables = (1+2);
+    writeenable(enables);
+
+
 }
 

--- a/test/sampleData/arduino/TCS3472.h
+++ b/test/sampleData/arduino/TCS3472.h
@@ -86,6 +86,12 @@ class TCS3472 {
          */
         int setinit(uint8_t data);
 
+        /**
+         * Enables features on device
+
+         */
+        void initonCreate();
+
 
     private:
         TwoWire* _wire;

--- a/test/sampleData/datasheet/TCS3472.tex
+++ b/test/sampleData/datasheet/TCS3472.tex
@@ -107,5 +107,37 @@ Enable RGBC and Power
 
 
 
+\raggedright
+
+\section{Functions}
+
+\centering
+\begin{tabular}{lc}
+\toprule
+  & Description \\
+\midrule
+init & Enables features on device \\
+\bottomrule
+\end{tabular}
+
+
+\raggedright
+\subsection{Function init }
+Enables features on device \\
+
+\centering
+\begin{tabular}{lcr}
+\toprule
+  & Inputs & Return \\
+\midrule
+onCreate &
+&
+\\
+\bottomrule
+\end{tabular}
+
+
+
+\raggedright
 
 \end{document}

--- a/test/sampleData/embedded-c/TCS3472.c
+++ b/test/sampleData/embedded-c/TCS3472.c
@@ -149,3 +149,18 @@ int tcs3472_set_init(
     return 0;
 }
 
+void tcs3472_init_oncreate(
+    void* val,
+    int (*read)(uint8_t, uint8_t, int*, uint8_t),
+    int (*write)(uint8_t, uint8_t, int*, uint8_t)
+) {
+    char enables; // Variable declaration
+
+
+    enables = (1+2);
+    tcs3472_writeenable(&enables, write);
+
+
+    *val = [];
+}
+

--- a/test/sampleData/embedded-c/TCS3472.h
+++ b/test/sampleData/embedded-c/TCS3472.h
@@ -108,5 +108,15 @@ int tcs3472_set_init(
     int (*write)(uint8_t, uint8_t, int*, uint8_t)
 );
 
+/**
+ * Enables features on device
+
+*/
+void tcs3472_init_oncreate(
+    void* val,
+    int (*read)(uint8_t, uint8_t, int*, uint8_t),
+    int (*write)(uint8_t, uint8_t, int*, uint8_t)
+);
+
 
 #endif

--- a/test/sampleData/kubos/TCS3472.c
+++ b/test/sampleData/kubos/TCS3472.c
@@ -41,6 +41,7 @@ int tcs3472_init(char* bus_name) {
     if (k_i2c_init(&bus_name, &i2c_bus) != I2C_OK) {
         return -1;
     }
+    tcs3472_init_oncreate();
 }
 
 void tcs3472_terminate() {
@@ -133,5 +134,16 @@ int tcs3472_set_init(uint8_t* data) {
         return -2;
     }
     return 0;
+}
+
+void tcs3472_init_oncreate(void* val) {
+    char enables; // Variable declaration
+
+
+    enables = (1+2);
+    tcs3472_writeenable(&enables);
+
+
+    return [];
 }
 

--- a/test/sampleData/kubos/TCS3472.h
+++ b/test/sampleData/kubos/TCS3472.h
@@ -86,5 +86,11 @@ int tcs3472_get_init(uint8_t* val);
  */
 int tcs3472_set_init(uint8_t* data);
 
+/**
+ * Enables features on device
+
+*/
+void tcs3472_init_oncreate(void* val);
+
 
 #endif

--- a/test/sampleData/raspberrypi/TCS3472.py
+++ b/test/sampleData/raspberrypi/TCS3472.py
@@ -46,6 +46,7 @@ class TCS3472:
     def __init__(self):
         # Initialize connection to peripheral
         self.bus = smbus.SMBus(1)
+        self.init_oncreate()
 
     def get_blue(self):
         """
@@ -136,3 +137,14 @@ class TCS3472:
         register_data = self.get_enable()
         register_data = register_data | data
         self.set_enable(register_data)
+    def init_oncreate(self):
+        """
+        Enables features on device
+
+        """
+        enables = None # Variable declaration
+
+        enables = (1+2)
+        self.set_enable(enables)
+
+        return []


### PR DESCRIPTION
With a function `init` and computed of `onCreate`, the constructor
executes the function.
Example done for TCS3472
Not applied to generic C as init function doesn't have fnc ptrs

Fixes #69