### PR TITLE
Fix a missing semicolon in generated Arduino code

### DIFF
--- a/templates/arduino.cpp
+++ b/templates/arduino.cpp
@@ -20,7 +20,7 @@
     uint8_t _datum;
     _wire->beginTransmission(DEVICE_ADDRESS);
     {# // Here is where I do _not_ put `write(REGISTER_ADDR) #}
-    _wire->requestFrom(DEVICE_ADDRESS, {{bytes}})
+    _wire->requestFrom(DEVICE_ADDRESS, {{bytes}});
     {# Read a byte at a time #}
     {% for n in range(bytes) %}
     _datum = _wire->read();

--- a/test/sampleData/arduino/BH1750FVI.cpp
+++ b/test/sampleData/arduino/BH1750FVI.cpp
@@ -191,7 +191,7 @@ uint16_t BH1750FVI::readLightIntensity() {
 
     uint8_t _datum;
     _wire->beginTransmission(DEVICE_ADDRESS);
-    _wire->requestFrom(DEVICE_ADDRESS, 2)
+    _wire->requestFrom(DEVICE_ADDRESS, 2);
     _datum = _wire->read();
     intensity = intensity << 8 | _datum;
     _datum = _wire->read();

--- a/test/sampleData/esp32/BH1750FVI.cpp
+++ b/test/sampleData/esp32/BH1750FVI.cpp
@@ -188,7 +188,7 @@ uint16_t BH1750FVI::readLightIntensity() {
 
     uint8_t _datum;
     _wire->beginTransmission(DEVICE_ADDRESS);
-    _wire->requestFrom(DEVICE_ADDRESS, 2)
+    _wire->requestFrom(DEVICE_ADDRESS, 2);
     _datum = _wire->read();
     intensity = intensity << 8 | _datum;
     _datum = _wire->read();


### PR DESCRIPTION
This affects both of Arduino and ESP32 backends. 