### PR TITLE
Add automated arduino builds on CI

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -45,6 +45,12 @@ steps:
     - 'peripherals/MCP9808.yaml'
     - 'peripherals/TCS3472.yaml'
   id: Sample codegen
+- name: wokwi/arduino-cli
+  args: ['arduino-cli', 'compile', '-o', '/home/wokwi/ci.hex', '-b', 'arduino:avr:uno', 'test/sampleData/arduino']
+  id: Arduino CI
+  waitFor: ['Sample codegen']
+  env:
+    - 'HOME=/home/wokwi'
 artifacts:
   objects:
     # Store generated files in a Cloud Storage bucket with the commit hash as directory

--- a/test/sampleData/arduino/arduino.ino
+++ b/test/sampleData/arduino/arduino.ino
@@ -1,0 +1,2 @@
+void setup() {}
+void loop() {}


### PR DESCRIPTION
This should compile all the Arduino code on every commit, and fail if there's any syntax error. 

I also had to add an `arduino.ino` file into the `sampleData` directory, otherwise the Arduino CLI won't build the project.

Fixes #104 