### PR TITLE
Update macros.jinja2

### DIFF
--- a/templates/macros.jinja2
+++ b/templates/macros.jinja2
@@ -84,7 +84,7 @@ limitations under the License.
 
 {% macro mask(startBit, endBit) -%}
 0b
-{%- for bit in range(16, 0, -1) -%}
+{%- for bit in range(15, -1, -1) -%}
 {% if bit > startBit or bit < endBit -%}
 0
 {%- else -%}

--- a/test/sampleData/arduino/Example.cpp
+++ b/test/sampleData/arduino/Example.cpp
@@ -185,7 +185,7 @@ uint8_t Example::getFieldA() {
     // '#/registers/RegisterA' > 'RegisterA'
     uint8_t val = readRegisterA();
     // Mask register value
-    val = val & 0b0000000001111000;
+    val = val & 0b0000000011110000;
     // Bitshift value
     val = val >> 4;
     return val;
@@ -205,7 +205,7 @@ uint8_t Example::getFieldC() {
     // '#/registers/RegisterA' > 'RegisterA'
     uint8_t val = readRegisterA();
     // Mask register value
-    val = val & 0b0000000000000001;
+    val = val & 0b0000000000000010;
     // Bitshift value
     val = val >> 1;
     return val;

--- a/test/sampleData/arduino/MCP4725.cpp
+++ b/test/sampleData/arduino/MCP4725.cpp
@@ -114,7 +114,7 @@ uint16_t MCP4725::getdigitalOut() {
     // '#/registers/EEPROM' > 'EEPROM'
     uint8_t val = readEEPROM();
     // Mask register value
-    val = val & 0b0000111111111111;
+    val = val & 0b0001111111111111;
     return val;
 }
 

--- a/test/sampleData/arduino/MCP9808.cpp
+++ b/test/sampleData/arduino/MCP9808.cpp
@@ -81,7 +81,7 @@ uint16_t MCP9808::getlimitHysteresis() {
     // '#/registers/configuration' > 'configuration'
     uint8_t val = readconfiguration();
     // Mask register value
-    val = val & 0b0000001100000000;
+    val = val & 0b0000011000000000;
     // Bitshift value
     val = val >> 9;
     return val;
@@ -91,7 +91,7 @@ uint16_t MCP9808::getshutdownMode() {
     // '#/registers/configuration' > 'configuration'
     uint8_t val = readconfiguration();
     // Mask register value
-    val = val & 0b0000000010000000;
+    val = val & 0b0000000100000000;
     // Bitshift value
     val = val >> 8;
     return val;

--- a/test/sampleData/arduino/TCS3472.cpp
+++ b/test/sampleData/arduino/TCS3472.cpp
@@ -171,7 +171,7 @@ uint8_t TCS3472::getinit() {
     // '#/registers/enable' > 'enable'
     uint8_t val = readenable();
     // Mask register value
-    val = val & 0b0000000001111111;
+    val = val & 0b0000000011111111;
     return val;
 }
 

--- a/test/sampleData/embedded-c/Example.c
+++ b/test/sampleData/embedded-c/Example.c
@@ -136,7 +136,7 @@ int example_get_fielda(
         return result;
     }
     // Mask register value
-    val = val & 0b0000000001111000;
+    val = val & 0b0000000011110000;
     // Bitshift value
     val = val >> 4;
     return 0;
@@ -174,7 +174,7 @@ int example_get_fieldc(
         return result;
     }
     // Mask register value
-    val = val & 0b0000000000000001;
+    val = val & 0b0000000000000010;
     // Bitshift value
     val = val >> 1;
     return 0;

--- a/test/sampleData/embedded-c/MCP4725.c
+++ b/test/sampleData/embedded-c/MCP4725.c
@@ -95,7 +95,7 @@ int mcp4725_get_digitalout(
         return result;
     }
     // Mask register value
-    val = val & 0b0000111111111111;
+    val = val & 0b0001111111111111;
     return 0;
 }
 

--- a/test/sampleData/embedded-c/MCP9808.c
+++ b/test/sampleData/embedded-c/MCP9808.c
@@ -71,7 +71,7 @@ int mcp9808_get_limithysteresis(
         return result;
     }
     // Mask register value
-    val = val & 0b0000001100000000;
+    val = val & 0b0000011000000000;
     // Bitshift value
     val = val >> 9;
     return 0;
@@ -87,7 +87,7 @@ int mcp9808_get_shutdownmode(
         return result;
     }
     // Mask register value
-    val = val & 0b0000000010000000;
+    val = val & 0b0000000100000000;
     // Bitshift value
     val = val >> 8;
     return 0;

--- a/test/sampleData/embedded-c/TCS3472.c
+++ b/test/sampleData/embedded-c/TCS3472.c
@@ -125,7 +125,7 @@ int tcs3472_get_init(
         return result;
     }
     // Mask register value
-    val = val & 0b0000000001111111;
+    val = val & 0b0000000011111111;
     return 0;
 }
 

--- a/test/sampleData/esp32/Example.cpp
+++ b/test/sampleData/esp32/Example.cpp
@@ -181,7 +181,7 @@ uint8_t Example::getFieldA() {
     // '#/registers/RegisterA' > 'RegisterA'
     uint8_t val = readRegisterA();
     // Mask register value
-    val = val & 0b0000000001111000;
+    val = val & 0b0000000011110000;
     // Bitshift value
     val = val >> 4;
     return val;
@@ -201,7 +201,7 @@ uint8_t Example::getFieldC() {
     // '#/registers/RegisterA' > 'RegisterA'
     uint8_t val = readRegisterA();
     // Mask register value
-    val = val & 0b0000000000000001;
+    val = val & 0b0000000000000010;
     // Bitshift value
     val = val >> 1;
     return val;

--- a/test/sampleData/esp32/MCP4725.cpp
+++ b/test/sampleData/esp32/MCP4725.cpp
@@ -111,7 +111,7 @@ uint16_t MCP4725::getdigitalOut() {
     // '#/registers/EEPROM' > 'EEPROM'
     uint8_t val = readEEPROM();
     // Mask register value
-    val = val & 0b0000111111111111;
+    val = val & 0b0001111111111111;
     return val;
 }
 

--- a/test/sampleData/esp32/MCP9808.cpp
+++ b/test/sampleData/esp32/MCP9808.cpp
@@ -78,7 +78,7 @@ uint16_t MCP9808::getlimitHysteresis() {
     // '#/registers/configuration' > 'configuration'
     uint8_t val = readconfiguration();
     // Mask register value
-    val = val & 0b0000001100000000;
+    val = val & 0b0000011000000000;
     // Bitshift value
     val = val >> 9;
     return val;
@@ -88,7 +88,7 @@ uint16_t MCP9808::getshutdownMode() {
     // '#/registers/configuration' > 'configuration'
     uint8_t val = readconfiguration();
     // Mask register value
-    val = val & 0b0000000010000000;
+    val = val & 0b0000000100000000;
     // Bitshift value
     val = val >> 8;
     return val;

--- a/test/sampleData/esp32/TCS3472.cpp
+++ b/test/sampleData/esp32/TCS3472.cpp
@@ -168,7 +168,7 @@ uint8_t TCS3472::getinit() {
     // '#/registers/enable' > 'enable'
     uint8_t val = readenable();
     // Mask register value
-    val = val & 0b0000000001111111;
+    val = val & 0b0000000011111111;
     return val;
 }
 

--- a/test/sampleData/espruino/Example.js
+++ b/test/sampleData/espruino/Example.js
@@ -181,7 +181,7 @@ Example.prototype.getFieldA = function() {
   // '#/registers/RegisterA' > 'RegisterA'
   var register = this.getRegisterA()
   // Mask register value
-  register = register & 0b0000000001111000
+  register = register & 0b0000000011110000
   // Bitshift value
   register = register >> 4
   return register
@@ -216,7 +216,7 @@ Example.prototype.getFieldC = function() {
   // '#/registers/RegisterA' > 'RegisterA'
   var register = this.getRegisterA()
   // Mask register value
-  register = register & 0b0000000000000001
+  register = register & 0b0000000000000010
   // Bitshift value
   register = register >> 1
   return register

--- a/test/sampleData/espruino/MCP4725.js
+++ b/test/sampleData/espruino/MCP4725.js
@@ -149,7 +149,7 @@ MCP4725.prototype.getdigitalOut = function() {
   // '#/registers/EEPROM' > 'EEPROM'
   var register = this.getEEPROM()
   // Mask register value
-  register = register & 0b0000111111111111
+  register = register & 0b0001111111111111
   return register
 }
 /**

--- a/test/sampleData/espruino/MCP9808.js
+++ b/test/sampleData/espruino/MCP9808.js
@@ -123,7 +123,7 @@ MCP9808.prototype.getlimitHysteresis = function() {
   // '#/registers/configuration' > 'configuration'
   var register = this.getconfiguration()
   // Mask register value
-  register = register & 0b0000001100000000
+  register = register & 0b0000011000000000
   // Bitshift value
   register = register >> 9
   return register
@@ -146,7 +146,7 @@ MCP9808.prototype.getshutdownMode = function() {
   // '#/registers/configuration' > 'configuration'
   var register = this.getconfiguration()
   // Mask register value
-  register = register & 0b0000000010000000
+  register = register & 0b0000000100000000
   // Bitshift value
   register = register >> 8
   return register

--- a/test/sampleData/espruino/TCS3472.js
+++ b/test/sampleData/espruino/TCS3472.js
@@ -167,7 +167,7 @@ TCS3472.prototype.getinit = function() {
   // '#/registers/enable' > 'enable'
   var register = this.getenable()
   // Mask register value
-  register = register & 0b0000000001111111
+  register = register & 0b0000000011111111
   return register
 }
 /**

--- a/test/sampleData/kubos/Example.c
+++ b/test/sampleData/kubos/Example.c
@@ -137,7 +137,7 @@ int example_get_fielda(uint8_t* val) {
         return result;
     }
     // Mask register value
-    val = val & 0b0000000001111000;
+    val = val & 0b0000000011110000;
     // Bitshift value
     val = val >> 4;
     return 0;
@@ -168,7 +168,7 @@ int example_get_fieldc(uint8_t* val) {
         return result;
     }
     // Mask register value
-    val = val & 0b0000000000000001;
+    val = val & 0b0000000000000010;
     // Bitshift value
     val = val >> 1;
     return 0;

--- a/test/sampleData/kubos/MCP4725.c
+++ b/test/sampleData/kubos/MCP4725.c
@@ -95,7 +95,7 @@ int mcp4725_get_digitalout(uint16_t* val) {
         return result;
     }
     // Mask register value
-    val = val & 0b0000111111111111;
+    val = val & 0b0001111111111111;
     return 0;
 }
 

--- a/test/sampleData/kubos/MCP9808.c
+++ b/test/sampleData/kubos/MCP9808.c
@@ -74,7 +74,7 @@ int mcp9808_get_limithysteresis(uint16_t* val) {
         return result;
     }
     // Mask register value
-    val = val & 0b0000001100000000;
+    val = val & 0b0000011000000000;
     // Bitshift value
     val = val >> 9;
     return 0;
@@ -87,7 +87,7 @@ int mcp9808_get_shutdownmode(uint16_t* val) {
         return result;
     }
     // Mask register value
-    val = val & 0b0000000010000000;
+    val = val & 0b0000000100000000;
     // Bitshift value
     val = val >> 8;
     return 0;

--- a/test/sampleData/kubos/TCS3472.c
+++ b/test/sampleData/kubos/TCS3472.c
@@ -116,7 +116,7 @@ int tcs3472_get_init(uint8_t* val) {
         return result;
     }
     // Mask register value
-    val = val & 0b0000000001111111;
+    val = val & 0b0000000011111111;
     return 0;
 }
 

--- a/test/sampleData/micropython/Example.py
+++ b/test/sampleData/micropython/Example.py
@@ -179,7 +179,7 @@ class Example:
         # '#/registers/RegisterA' > 'RegisterA'
         val = self.get_registera()
         # Mask register value
-        val = val & 0b0000000001111000
+        val = val & 0b0000000011110000
         # Bitshift value
         val = val >> 4
         return val
@@ -206,7 +206,7 @@ class Example:
         # '#/registers/RegisterA' > 'RegisterA'
         val = self.get_registera()
         # Mask register value
-        val = val & 0b0000000000000001
+        val = val & 0b0000000000000010
         # Bitshift value
         val = val >> 1
         return val

--- a/test/sampleData/micropython/MCP4725.py
+++ b/test/sampleData/micropython/MCP4725.py
@@ -134,7 +134,7 @@ class MCP4725:
         # '#/registers/EEPROM' > 'EEPROM'
         val = self.get_eeprom()
         # Mask register value
-        val = val & 0b0000111111111111
+        val = val & 0b0001111111111111
         return val
 
     def set_digitalout(self, data):

--- a/test/sampleData/micropython/MCP9808.py
+++ b/test/sampleData/micropython/MCP9808.py
@@ -116,7 +116,7 @@ class MCP9808:
         # '#/registers/configuration' > 'configuration'
         val = self.get_configuration()
         # Mask register value
-        val = val & 0b0000001100000000
+        val = val & 0b0000011000000000
         # Bitshift value
         val = val >> 9
         return val
@@ -134,7 +134,7 @@ class MCP9808:
         # '#/registers/configuration' > 'configuration'
         val = self.get_configuration()
         # Mask register value
-        val = val & 0b0000000010000000
+        val = val & 0b0000000100000000
         # Bitshift value
         val = val >> 8
         return val

--- a/test/sampleData/micropython/TCS3472.py
+++ b/test/sampleData/micropython/TCS3472.py
@@ -148,7 +148,7 @@ class TCS3472:
         # '#/registers/enable' > 'enable'
         val = self.get_enable()
         # Mask register value
-        val = val & 0b0000000001111111
+        val = val & 0b0000000011111111
         return val
 
     def set_init(self, data):

--- a/test/sampleData/raspberrypi/Example.py
+++ b/test/sampleData/raspberrypi/Example.py
@@ -162,7 +162,7 @@ class Example:
         # '#/registers/RegisterA' > 'RegisterA'
         val = self.get_registera()
         # Mask register value
-        val = val & 0b0000000001111000
+        val = val & 0b0000000011110000
         # Bitshift value
         val = val >> 4
         return val
@@ -189,7 +189,7 @@ class Example:
         # '#/registers/RegisterA' > 'RegisterA'
         val = self.get_registera()
         # Mask register value
-        val = val & 0b0000000000000001
+        val = val & 0b0000000000000010
         # Bitshift value
         val = val >> 1
         return val

--- a/test/sampleData/raspberrypi/MCP4725.py
+++ b/test/sampleData/raspberrypi/MCP4725.py
@@ -123,7 +123,7 @@ class MCP4725:
         # '#/registers/EEPROM' > 'EEPROM'
         val = self.get_eeprom()
         # Mask register value
-        val = val & 0b0000111111111111
+        val = val & 0b0001111111111111
         return val
 
     def set_digitalout(self, data):

--- a/test/sampleData/raspberrypi/MCP9808.py
+++ b/test/sampleData/raspberrypi/MCP9808.py
@@ -117,7 +117,7 @@ class MCP9808:
         # '#/registers/configuration' > 'configuration'
         val = self.get_configuration()
         # Mask register value
-        val = val & 0b0000001100000000
+        val = val & 0b0000011000000000
         # Bitshift value
         val = val >> 9
         return val
@@ -135,7 +135,7 @@ class MCP9808:
         # '#/registers/configuration' > 'configuration'
         val = self.get_configuration()
         # Mask register value
-        val = val & 0b0000000010000000
+        val = val & 0b0000000100000000
         # Bitshift value
         val = val >> 8
         return val

--- a/test/sampleData/raspberrypi/TCS3472.py
+++ b/test/sampleData/raspberrypi/TCS3472.py
@@ -124,7 +124,7 @@ class TCS3472:
         # '#/registers/enable' > 'enable'
         val = self.get_enable()
         # Mask register value
-        val = val & 0b0000000001111111
+        val = val & 0b0000000011111111
         return val
 
     def set_init(self, data):


### PR DESCRIPTION
There is an off by one error in this macro.  Start / end bits of (4:1) would create 0b0000000000001111 instead of 0b0000000000011110.  If start and end bits were both 0, no 1 appears in the output mask at all.