### PR TITLE
I2cdevice ast issue

### DIFF
--- a/templates/i2c-device.py
+++ b/templates/i2c-device.py
@@ -43,7 +43,7 @@ I2C_ADDR = {{i2c.address}}
 {% if key in template.registersToFields %}
 {{key.upper()}} = Register('{{key.upper()}}', {{register.address}}, fields=(
     {% for field in template.registersToFields[key] %}
-    BitField('{{field.key}}', {{utils.mask(field.bitStart, field.bitEnd)}}, bitwidth={{field.bitStart - field.bitEnd + 1}}{% if i2c.endian == 'little' %}, values_in=_byte_swap, values_out=_byte_swap{% endif %}{% if field.type == 'enum' %}, values_map={{values_map(field)}}{% endif %})
+    BitField('{{field.key}}', {{utils.mask(field.bitStart, field.bitEnd)}}, bitwidth={{field.bitStart - field.bitEnd + 1}}{% if i2c.endian == 'little' %}, values_in=_byte_swap, values_out=_byte_swap{% endif %}{% if field.type == 'enum' %}, values_map={{values_map(field)}}{% endif %}){{',' if not loop.last }}
     {% endfor %}
 ), read_only={{register.readWrite == 'R'}}, bitwidth={{register.length}})
 {% else %}

--- a/templates/i2c-device.py
+++ b/templates/i2c-device.py
@@ -43,7 +43,7 @@ I2C_ADDR = {{i2c.address}}
 {% if key in template.registersToFields %}
 {{key.upper()}} = Register('{{key.upper()}}', {{register.address}}, fields=(
     {% for field in template.registersToFields[key] %}
-    BitField('{{field.key}}', {{utils.mask(field.bitStart, field.bitEnd)}}, bitwidth={{field.bitStart - field.bitEnd + 1}} {% if i2c.endian == 'little' %}, values_in=_byte_swap, values_out=_byte_swap{% endif %} {% if field.type == 'enum' %}, values_map={{values_map(field)}}{% endif %})
+    BitField('{{field.key}}', {{utils.mask(field.bitStart, field.bitEnd)}}, bitwidth={{field.bitStart - field.bitEnd + 1}}{% if i2c.endian == 'little' %}, values_in=_byte_swap, values_out=_byte_swap{% endif %}{% if field.type == 'enum' %}, values_map={{values_map(field)}}{% endif %})
     {% endfor %}
 ), read_only={{register.readWrite == 'R'}}, bitwidth={{register.length}})
 {% else %}

--- a/test/sampleData/i2c-device/ADS1015.py
+++ b/test/sampleData/i2c-device/ADS1015.py
@@ -24,11 +24,11 @@ CONFIG = Register('CONFIG', 1, fields=(
         CHANNEL_2: 1,
         CHANNEL_3: 2,
         CHANNEL_4: 3
-    })
+    }),
     BitField('DeviceOperatingMode', 0b0000000100000000, bitwidth=1, values_in=_byte_swap, values_out=_byte_swap, values_map={
         CONTINUOUS_CONVERSION: 0,
         SINGLE_SHOT: 1
-    })
+    }),
     BitField('ProgrammableGain', 0b0000111000000000, bitwidth=3, values_in=_byte_swap, values_out=_byte_swap, values_map={
         PGA0_256: 5,
         PGA0_512: 4,
@@ -36,7 +36,7 @@ CONFIG = Register('CONFIG', 1, fields=(
         PGA2_048V: 2,
         PGA4_096V: 1,
         PGA6_144V: 0
-    })
+    }),
     BitField('SampleRate', 0b0000000011100000, bitwidth=3, values_in=_byte_swap, values_out=_byte_swap, values_map={
         HZ128: 0,
         HZ1600: 4,

--- a/test/sampleData/i2c-device/ADS1015.py
+++ b/test/sampleData/i2c-device/ADS1015.py
@@ -19,17 +19,17 @@ from i2cdevice import Device, Register, BitField
 I2C_ADDR = 73
 
 CONFIG = Register('CONFIG', 1, fields=(
-    BitField('Channel', 0b0011100000000000, bitwidth=3, values_in=_byte_swap, values_out=_byte_swap, values_map={
+    BitField('Channel', 0b0111000000000000, bitwidth=3, values_in=_byte_swap, values_out=_byte_swap, values_map={
         CHANNEL_1: 0,
         CHANNEL_2: 1,
         CHANNEL_3: 2,
         CHANNEL_4: 3
     })
-    BitField('DeviceOperatingMode', 0b0000000010000000, bitwidth=1, values_in=_byte_swap, values_out=_byte_swap, values_map={
+    BitField('DeviceOperatingMode', 0b0000000100000000, bitwidth=1, values_in=_byte_swap, values_out=_byte_swap, values_map={
         CONTINUOUS_CONVERSION: 0,
         SINGLE_SHOT: 1
     })
-    BitField('ProgrammableGain', 0b0000011100000000, bitwidth=3, values_in=_byte_swap, values_out=_byte_swap, values_map={
+    BitField('ProgrammableGain', 0b0000111000000000, bitwidth=3, values_in=_byte_swap, values_out=_byte_swap, values_map={
         PGA0_256: 5,
         PGA0_512: 4,
         PGA1_024V: 3,
@@ -37,7 +37,7 @@ CONFIG = Register('CONFIG', 1, fields=(
         PGA4_096V: 1,
         PGA6_144V: 0
     })
-    BitField('SampleRate', 0b0000000001110000, bitwidth=3, values_in=_byte_swap, values_out=_byte_swap, values_map={
+    BitField('SampleRate', 0b0000000011100000, bitwidth=3, values_in=_byte_swap, values_out=_byte_swap, values_map={
         HZ128: 0,
         HZ1600: 4,
         HZ2400: 5,

--- a/test/sampleData/i2c-device/Example.py
+++ b/test/sampleData/i2c-device/Example.py
@@ -22,15 +22,15 @@ I2C_ADDR_48 = 48
 I2C_ADDR = [I2C_ADDR_16, I2C_ADDR_32, I2C_ADDR_48]
 
 REGISTERA = Register('REGISTERA', 0, fields=(
-    BitField('FieldA', 0b0000000001111000, bitwidth=4)
-    BitField('FieldB', 0b0000000000000110, bitwidth=2, values_map={
+    BitField('FieldA', 0b0000000011110000, bitwidth=4)
+    BitField('FieldB', 0b0000000000001100, bitwidth=2, values_map={
         VAL_1: 1,
         VAL_2: 2,
         VAL_3: 4,
         VAL_4: 8
     })
-    BitField('FieldC', 0b0000000000000001, bitwidth=1)
-    BitField('FieldD', 0b0000000000000000, bitwidth=1)
+    BitField('FieldC', 0b0000000000000010, bitwidth=1)
+    BitField('FieldD', 0b0000000000000001, bitwidth=1)
 ), read_only=False, bitwidth=8)
 REGISTERB = Register('REGISTERB', 1, read_only=False, bitwidth=16)
 REGISTERC = Register('REGISTERC', 2, read_only=False, bitwidth=32)

--- a/test/sampleData/i2c-device/Example.py
+++ b/test/sampleData/i2c-device/Example.py
@@ -22,14 +22,14 @@ I2C_ADDR_48 = 48
 I2C_ADDR = [I2C_ADDR_16, I2C_ADDR_32, I2C_ADDR_48]
 
 REGISTERA = Register('REGISTERA', 0, fields=(
-    BitField('FieldA', 0b0000000011110000, bitwidth=4)
+    BitField('FieldA', 0b0000000011110000, bitwidth=4),
     BitField('FieldB', 0b0000000000001100, bitwidth=2, values_map={
         VAL_1: 1,
         VAL_2: 2,
         VAL_3: 4,
         VAL_4: 8
-    })
-    BitField('FieldC', 0b0000000000000010, bitwidth=1)
+    }),
+    BitField('FieldC', 0b0000000000000010, bitwidth=1),
     BitField('FieldD', 0b0000000000000001, bitwidth=1)
 ), read_only=False, bitwidth=8)
 REGISTERB = Register('REGISTERB', 1, read_only=False, bitwidth=16)

--- a/test/sampleData/i2c-device/MCP4725.py
+++ b/test/sampleData/i2c-device/MCP4725.py
@@ -19,7 +19,7 @@ from i2cdevice import Device, Register, BitField
 I2C_ADDR = 98
 
 EEPROM = Register('EEPROM', 96, fields=(
-    BitField('digitalOut', 0b0000111111111111, bitwidth=13, values_in=_byte_swap, values_out=_byte_swap, values_map={
+    BitField('digitalOut', 0b0001111111111111, bitwidth=13, values_in=_byte_swap, values_out=_byte_swap, values_map={
         GND: 0,
         VCC: 4095
     })

--- a/test/sampleData/i2c-device/MCP9808.py
+++ b/test/sampleData/i2c-device/MCP9808.py
@@ -32,7 +32,7 @@ CONFIGURATION = Register('CONFIGURATION', 1, fields=(
         Temp_1C5: 1,
         Temp_3C: 2,
         Temp_6C: 3
-    })
+    }),
     BitField('shutdownMode', 0b0000000100000000, bitwidth=1, values_map={
         continousConversion: 0,
         shutdown: 1

--- a/test/sampleData/i2c-device/MCP9808.py
+++ b/test/sampleData/i2c-device/MCP9808.py
@@ -27,13 +27,13 @@ I2C_ADDR_31 = 31
 I2C_ADDR = [I2C_ADDR_24, I2C_ADDR_25, I2C_ADDR_26, I2C_ADDR_27, I2C_ADDR_28, I2C_ADDR_29, I2C_ADDR_30, I2C_ADDR_31]
 
 CONFIGURATION = Register('CONFIGURATION', 1, fields=(
-    BitField('limitHysteresis', 0b0000001100000000, bitwidth=2, values_map={
+    BitField('limitHysteresis', 0b0000011000000000, bitwidth=2, values_map={
         Temp_0C: 0,
         Temp_1C5: 1,
         Temp_3C: 2,
         Temp_6C: 3
     })
-    BitField('shutdownMode', 0b0000000010000000, bitwidth=1, values_map={
+    BitField('shutdownMode', 0b0000000100000000, bitwidth=1, values_map={
         continousConversion: 0,
         shutdown: 1
     })

--- a/test/sampleData/i2c-device/TCS3472.py
+++ b/test/sampleData/i2c-device/TCS3472.py
@@ -21,7 +21,7 @@ I2C_ADDR = 41
 BLUE = Register('BLUE', 186, read_only=True, bitwidth=16)
 CLEAR = Register('CLEAR', 180, read_only=True, bitwidth=16)
 ENABLE = Register('ENABLE', 128, fields=(
-    BitField('init', 0b0000000001111111, bitwidth=8, values_map={
+    BitField('init', 0b0000000011111111, bitwidth=8, values_map={
         Power: 1,
         RGBC: 2
     })

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -108,9 +108,9 @@ class TestCodegen(unittest.TestCase):
         self.generatePeripheralTag('espruino')
         self.compareFiles('espruino', 'js')
 
-    def test_Micropython(self):
+    def test_I2CDevice(self):
         self.generatePeripheralTag('i2cdevice')
-        self.compareFiles('i2cdevice', 'py')
+        self.compareFiles('i2c-device', 'py')
 
     def test_Kubos(self):
         self.generatePeripheralTag('kubos')


### PR DESCRIPTION
Two tests had the same function name, so only the later one was run (comparing the micropython template).  This patch:

- Fixes the test runner so that i2c-device outputs are compared
- Fixes a small whitespace issue in the template when BitFields are used
- Updated the test reference files per the off-by-one error (see https://github.com/google/cyanobyte/pull/222)

Also, the files generated by the i2c-device template are not valid python, if BitFields are used.  The needs to be a comma between the BitField entries.