### PR TITLE
Validator packaging

### DIFF
--- a/cyanobyte.egg-info/MANIFEST.in
+++ b/cyanobyte.egg-info/MANIFEST.in
@@ -1,1 +1,2 @@
 include templates/*.*
+include spec/cyanobyte.schema.json

--- a/cyanobyte.egg-info/PKG-INFO
+++ b/cyanobyte.egg-info/PKG-INFO
@@ -6,12 +6,15 @@ Home-page: https://github.com/google/cyanobyte
 Author: Google Inc.
 Author-email: fleker+cyanobyte@google.com
 License: UNKNOWN
-Description: # Peripheral Codegen
+Description: # Cyanobyte - Machine readable datasheets for documentation & codegen
+        
+        ![logo](https://github.com/google/cyanobyte/raw/master/cyanobyte_logo.png)
+        
         This project is an example of how to describe peripherals with an intermediary layer (YAML files) which can be used to generate library files for a peripheral.
         
         It can also generate reference documentation for a peripheral, useful for embedding into datasheets.
         
-        The tool works well for I2C devices, while SPI support is in alpha.
+        The tool works well for I2C devices, while SPI support is in progress.
         
         This is not an official Google product.
         
@@ -63,6 +66,10 @@ Description: # Peripheral Codegen
         
         For more advanced development, also install the dev list.
         `pip install -r requirements-dev.txt --user`
+        
+        ## Projects using Cyanobyte
+        
+        [File an issue or pull request](https://github.com/google/cyanobyte/issues) to add your project to the list.
         
         ## Contributors
         Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.

--- a/cyanobyte.egg-info/SOURCES.txt
+++ b/cyanobyte.egg-info/SOURCES.txt
@@ -6,6 +6,8 @@ LICENSE
 README.md
 cloudbuild-deploy.yaml
 cloudbuild.yaml
+cyanobyte_logo.png
+cyanobyte_logo_x32.png
 emboss.md
 get-pip.py
 requirements-dev.txt
@@ -34,6 +36,8 @@ docs/content/search.md
 docs/content/blog/_index.md
 docs/content/blog/news/2019-09/live.md
 docs/content/blog/news/2020-04/datasheet.md
+docs/content/blog/news/2021-02/webpage.md
+docs/content/blog/news/2021-03/callbacks.md
 docs/content/community/_index.md
 docs/content/docs/_index.md
 docs/content/docs/Generate These Docs/_index.md
@@ -42,12 +46,14 @@ docs/content/docs/Open Source/lint.md
 docs/content/docs/Open Source/unittest.md
 docs/content/docs/Principle Philosophies/_index.md
 docs/content/docs/Principle Philosophies/cujs.md
+docs/content/docs/Principle Philosophies/get-started.md
 docs/content/docs/Principle Philosophies/philosophy.md
 docs/content/docs/Principle Philosophies/pseudoyaml.md
 docs/content/docs/Principle Philosophies/roadmap.md
 docs/content/docs/Principle Philosophies/sample_spec.md
 docs/content/docs/Reference/_index.md
 docs/content/docs/Reference/emboss.md
+docs/content/docs/Reference/pseudoyaml.md
 docs/content/docs/Reference/quirks.md
 docs/content/docs/Reference/specification.md
 docs/content/docs/Reference/templates.md
@@ -71,6 +77,7 @@ peripherals/example.yaml
 peripherals/examplespi-emboss.yaml
 peripherals/examplespi-register.yaml
 peripherals/float.emb
+spec/__init__.py
 spec/cyanobyte.schema.json
 templates/__init__.py
 templates/arduino.cpp

--- a/cyanobyte.egg-info/entry_points.txt
+++ b/cyanobyte.egg-info/entry_points.txt
@@ -1,4 +1,4 @@
 [console_scripts]
 cyanobyte-codegen = cyanobyte.codegen:gen
-cyanobyte-validator = cyanobyte.validator:click_valdiate
+cyanobyte-validator = cyanobyte.validator:click_validate
 

--- a/cyanobyte.egg-info/top_level.txt
+++ b/cyanobyte.egg-info/top_level.txt
@@ -1,2 +1,3 @@
 cyanobyte
+spec
 templates

--- a/cyanobyte/validator.py
+++ b/cyanobyte/validator.py
@@ -45,7 +45,13 @@ def cyanobyte_validate(input_files):
         input_files: A list of CyanoByte documents to validate.
     """
     # Load the JSON Schema file
-    with open("spec/cyanobyte.schema.json", "r") as schema_json:
+    path = "spec/cyanobyte.schema.json"
+    try:
+        import pkg_resources
+        path = pkg_resources.resource_filename('spec', 'cyanobyte.schema.json')
+    except:pass
+
+    with open(path, "r") as schema_json:
         schema = json.load(schema_json)
 
     # Validate each document against the schema

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     entry_points={
         "console_scripts": [
             "cyanobyte-codegen=cyanobyte.codegen:gen",
-            "cyanobyte-validator=cyanobyte.validator:click_valdiate"
+            "cyanobyte-validator=cyanobyte.validator:click_validate"
         ],
     },
     setup_requires=['setuptools_scm'],

--- a/spec/__init__.py
+++ b/spec/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# Copyright (C) 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -1,5 +1,5 @@
 import unittest
-from cyanobyte.validator import cyanobyte_valdiate
+from cyanobyte.validator import cyanobyte_validate
 from jsonschema.exceptions import ValidationError
 
 
@@ -7,7 +7,7 @@ class TestValidatorGeneral(unittest.TestCase):
     def test_blank_file(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/blank.yaml']
         )
 
@@ -15,76 +15,76 @@ class TestValidatorGeneral(unittest.TestCase):
 class TestValidatorInfo(unittest.TestCase):
     def test_valid(self):
         self.assertIsNone(
-            cyanobyte_valdiate(['test/sampleData/validator/info/valid.yaml'],)
+            cyanobyte_validate(['test/sampleData/validator/info/valid.yaml'],)
         )
 
     def test_missing_cyanobyte_version(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/info/missing_cyanobyte_version.yaml']
         )
 
     def test_missing_info(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/info/missing_info.yaml']
         )
 
     def test_missing_title(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/info/missing_title.yaml']
         )
 
     def test_missing_description(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/info/missing_description.yaml']
         )
 
     def test_missing_contact(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/info/missing_contact.yaml']
         )
 
     def test_missing_contact_name(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/info/missing_contact_name.yaml']
         )
 
     def test_missing_contact_url(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/info/missing_contact_url.yaml']
         )
 
     def test_missing_contact_email(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/info/missing_title.yaml']
         )
 
     def test_missing_license(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/info/missing_license.yaml']
         )
 
     def test_missing_version(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/info/missing_version.yaml']
         )
 
@@ -92,58 +92,58 @@ class TestValidatorInfo(unittest.TestCase):
 class TestValidatorI2c(unittest.TestCase):
     def test_valid(self):
         self.assertIsNone(
-            cyanobyte_valdiate(['test/sampleData/validator/i2c/valid.yaml'],)
+            cyanobyte_validate(['test/sampleData/validator/i2c/valid.yaml'],)
         )
 
     def test_missing_address_type(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/i2c/missing_address_type.yaml']
         )
 
     def test_missing_address(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/i2c/missing_address.yaml']
         )
 
     def test_missing_address_mask(self):
         self.assertRaises(
             ValidationError,
-            cyanobyte_valdiate,
+            cyanobyte_validate,
             ['test/sampleData/validator/i2c/missing_address_mask.yaml']
         )
 
 
 class TestValidatorPeripherals(unittest.TestCase):
     def test_ads1015(self):
-        self.assertIsNone(cyanobyte_valdiate(['peripherals/ADS1015.yaml']))
+        self.assertIsNone(cyanobyte_validate(['peripherals/ADS1015.yaml']))
 
     def test_bh1750fvi(self):
-        self.assertIsNone(cyanobyte_valdiate(['peripherals/BH1750FVI.yaml']))
+        self.assertIsNone(cyanobyte_validate(['peripherals/BH1750FVI.yaml']))
 
     def test_bmp180(self):
-        self.assertIsNone(cyanobyte_valdiate(['peripherals/BMP180.yaml']))
+        self.assertIsNone(cyanobyte_validate(['peripherals/BMP180.yaml']))
 
     def test_bmp280(self):
-        self.assertIsNone(cyanobyte_valdiate(['peripherals/BMP280.yaml']))
+        self.assertIsNone(cyanobyte_validate(['peripherals/BMP280.yaml']))
 
     def test_example(self):
-        self.assertIsNone(cyanobyte_valdiate(['peripherals/example.yaml']))
+        self.assertIsNone(cyanobyte_validate(['peripherals/example.yaml']))
 
     def test_lsm303d(self):
-        self.assertIsNone(cyanobyte_valdiate(['peripherals/LSM303D.yaml']))
+        self.assertIsNone(cyanobyte_validate(['peripherals/LSM303D.yaml']))
 
     def test_mcp4725(self):
-        self.assertIsNone(cyanobyte_valdiate(['peripherals/MCP4725.yaml']))
+        self.assertIsNone(cyanobyte_validate(['peripherals/MCP4725.yaml']))
 
     def test_mcp9808(self):
-        self.assertIsNone(cyanobyte_valdiate(['peripherals/MCP9808.yaml']))
+        self.assertIsNone(cyanobyte_validate(['peripherals/MCP9808.yaml']))
 
     def test_tcs3472(self):
-        self.assertIsNone(cyanobyte_valdiate(['peripherals/TCS3472.yaml']))
+        self.assertIsNone(cyanobyte_validate(['peripherals/TCS3472.yaml']))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When I corrected the typo valdiate -> validate some thing broke. This fixes it.
Also, when installing the package the validator couldn't find the spec as it's not included in the packages. This also fixes it by including it as a module.
However, since the templates and spec are in a separate folder from cyanobyte, when they are installed they create a folder for each in the lib/site-packages directory. This is weird and could create name collisions. I suggest to move the spec inside the cyanobyte folder, and be part of the module. 
Templates could be also moved, or left there and renamed to cyanobyte-templates for example. Or removed... Is there anybody that uses the templates provided by the module? I wasn't aware they where included since I took a look on the spec thingy.